### PR TITLE
商品売買の状況登録

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 |email|string|null: false, unique: true|
 |password|string|null: false|
 ### Association
-- has_many :buyed_items, foreign_key: "buyer_id", class_name: "items"
-- has_many :saling_items, foreign_key: "seller_id", class_name: "items"
-- has_many :sold_items, foreign_key: "seller_id", class_name: "items"
+- has_many :bought_items, foreign_key: "buyer_id", class_name: "Item"
+- has_many :sales_items, foreign_key: "seller_id", class_name: "Item"
+- has_many :sold_items, foreign_key: "seller_id", class_name: "Item"
 - has_one :profile, dependent: :destroy
 - has_one :credit_card, dependent: :destroy
 - has_one :address, dependent: :destroy
@@ -67,11 +67,11 @@
 |shipping_date_id|integer|null:false|
 |brand|text||
 |category_id|references|foreign_key:true|
-|seller_id|references|null:false, foreign_key:true|
-|buyer_id|references|foreign_key:true|
+|seller_id|integer|null:false|
+|buyer_id|integer||
 ### Association
-- belongs_to :seller, class_name: "User"
-- belongs_to :buyer, class_name: "User"
+- belongs_to :seller, class_name: "User", foreign_key: "seller_id"
+- belongs_to :buyer, class_name: "User", foreign_key: "buyer_id", optional: true
 - has_many :images, dependent: :destroy
 - belongs_to_active_hash :prefecture
 - belongs_to_active_hash :shipping_date

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,7 +19,7 @@ class ItemsController < ApplicationController
 
   private
   def item_params
-    params.require(:item).permit(:name, :price, :explain, :size, :prefecture_id, :brand, :shipping_date_id, :item_status_id, :postage_id, :category_id, images_attributes: [:src])
+    params.require(:item).permit(:name, :price, :explain, :size, :prefecture_id, :brand, :shipping_date_id, :item_status_id, :postage_id, :category_id, images_attributes: [:src]).merge(seller_id: current_user.id)
   end
 
   def buy

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,5 @@
 class Item < ApplicationRecord
   belongs_to :seller, class_name: "User"
-  belongs_to :buyer, class_name: "User"
   belongs_to :category
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,6 @@
 class Item < ApplicationRecord
+  belongs_to :seller, class_name: "User"
+  belongs_to :buyer, class_name: "User"
   belongs_to :category
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true
@@ -12,7 +14,6 @@ class Item < ApplicationRecord
   validates :prefecture_id, presence: true
   validates :postage_id, presence: true
   validates :shipping_date_id, presence: true
-
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :prefecture

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,6 +14,7 @@ class Item < ApplicationRecord
   validates :prefecture_id, presence: true
   validates :postage_id, presence: true
   validates :shipping_date_id, presence: true
+  validates :seller_id, presence: true
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :prefecture

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,5 @@
 class Item < ApplicationRecord
-  belongs_to :seller, class_name: "User"
+  belongs_to :seller, class_name: "User", foreign_key: "seller_id"
   belongs_to :category
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,6 @@
 class Item < ApplicationRecord
   belongs_to :seller, class_name: "User", foreign_key: "seller_id"
+  belongs_to :buyer, class_name: "User", foreign_key: "buyer_id", optional: true
   belongs_to :category
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true

--- a/app/models/item_status.rb
+++ b/app/models/item_status.rb
@@ -1,12 +1,12 @@
 class ItemStatus < ActiveHash::Base
   include ActiveHash::Associations
   field :choice
-  add :id => 1, :choice => "新品、未使用"
-  add :id => 2, :choice => "未使用に近い"
-  add :id => 3, :choice => "目立った傷や汚れなし"
-  add :id => 4, :choice => "やや傷や汚れあり"
-  add :id => 5, :choice => "傷や汚れあり"
-  add :id => 6, :choice => "全体的に状態が悪い"
+  add id: 1, choice: "新品、未使用"
+  add id: 2, choice: "未使用に近い"
+  add id: 3, choice: "目立った傷や汚れなし"
+  add id: 4, choice: "やや傷や汚れあり"
+  add id: 5, choice: "傷や汚れあり"
+  add id: 6, choice: "全体的に状態が悪い"
 
   has_many :items
 end

--- a/app/models/postage.rb
+++ b/app/models/postage.rb
@@ -1,9 +1,9 @@
 class Postage < ActiveHash::Base
   include ActiveHash::Associations
   field :choice
-  add :id => 1, :choice => "1~2日で発送"
-  add :id => 2, :choice => "2~3日で発送"
-  add :id => 3, :choice => "4~7日で発送"
+  add id: 1, choice: "1~2日で発送"
+  add id: 2, choice: "2~3日で発送"
+  add id: 3, choice: "4~7日で発送"
 
   has_many :items
 end

--- a/app/models/shipping_date.rb
+++ b/app/models/shipping_date.rb
@@ -1,8 +1,8 @@
 class ShippingDate < ActiveHash::Base
   include ActiveHash::Associations
   field :choice
-  add :id => 1, :choice => "送料込み(出品者負担)"
-  add :id => 2, :choice => "着払い(購入者負担)"
+  add id: 1, choice: "送料込み(出品者負担)"
+  add id: 2, choice: "着払い(購入者負担)"
 
   has_many :items
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,4 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   validates :nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birth_year, :birth_month, :birth_day ,presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   validates :nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birth_year, :birth_month, :birth_day ,presence: true
   has_one :address, dependent: :destroy
+  has_many :bought_items, foreign_key: "buyer_id", class_name: "Item"
+  has_many :sales_items, -> { where buyer_id: nil }, foreign_key: "seller_id", class_name: "Item"
+  has_many :sold_items, -> { where.not buyer_id: nil }, foreign_key: "seller_id", class_name: "Item"
 end

--- a/app/views/items/_sell_btn.html.haml
+++ b/app/views/items/_sell_btn.html.haml
@@ -1,3 +1,3 @@
 .Sell-btn
   %p 出品する
-  = link_to image_tag('material/icon/icon_camera.png', alt: '出品ページへのリンクボタン', width: '54', height: '54'), new_items_path
+  = link_to image_tag('material/icon/icon_camera.png', alt: '出品ページへのリンクボタン', width: '54', height: '54'), new_item_path

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -70,7 +70,7 @@
   
         .delivery-form
           %h3.delivery-form__about__delivery 配送について
-          = link_to '?', new_items_path, class: 'form--question'
+          = link_to '?', new_item_path, class: 'form--question'
           .delivery-form__box
             .delivery-form__box__top
               %h3.delivery-form__box__top__name
@@ -98,7 +98,7 @@
 
         .product-price
           %h3.product-price__name 価格(300〜9,999,999)
-          = link_to '?', new_items_path, class: 'form--question'
+          = link_to '?', new_item_path, class: 'form--question'
           .product-price__form
             .product-price__form__left
               %h3.product-price__form__name
@@ -112,19 +112,19 @@
         .submit-button
           .actions
             = f.submit "出品する", class: "btn--lightblue"
-          = link_to 'もどる', new_items_path, class: 'btn--bule'
+          = link_to 'もどる', new_item_path, class: 'btn--bule'
           .subimit-button__text
-            = link_to '禁止されている出品', new_items_path, class: 'submit__text'
+            = link_to '禁止されている出品', new_item_path, class: 'submit__text'
             、
-            = link_to '行為', new_items_path, class: 'submit__text'
+            = link_to '行為', new_item_path, class: 'submit__text'
             を必ずご確認ください。
             %p.sell--content5__p
               またブランド品でシリアルナンバー等がある場合はご記載ください。
-              = link_to '偽ブランドの販売', new_items_path, class: 'submit__text'
+              = link_to '偽ブランドの販売', new_item_path, class: 'submit__text'
               は犯罪であり処罰される可能性があります。
             %p.sell--content5__p
               また、出品をもちまして
-              = link_to '加盟店規約', new_items_path, class: 'submit__text'
+              = link_to '加盟店規約', new_item_path, class: 'submit__text'
               に同意したことになります。
 
 .exhibit-page__footer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
     post 'addresses', to: 'users/registrations#create_address'
   end
   root 'items#index'
-  resource :items, only: [:new, :create] do
+  resources :items, only: [:new, :create] do
     member do
       get 'buy'
     end

--- a/db/migrate/20200814074941_add_user_ids_to_items.rb
+++ b/db/migrate/20200814074941_add_user_ids_to_items.rb
@@ -1,0 +1,6 @@
+class AddUserIdsToItems < ActiveRecord::Migration[6.0]
+  def change
+    add_column :items, :seller_id, :integer, null: false
+    add_column :items, :buyer_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_14_003200) do
+ActiveRecord::Schema.define(version: 2020_08_14_074941) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -57,6 +57,8 @@ ActiveRecord::Schema.define(version: 2020_08_14_003200) do
     t.integer "postage_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "seller_id", null: false
+    t.integer "buyer_id"
     t.index ["category_id"], name: "index_items_on_category_id"
   end
 


### PR DESCRIPTION
# What
商品の売買状況を把握するために、itemsテーブルにseller_idカラムとbuyer_idカラムを追加する。seller_idカラムには出品者のuser_idを、buyer_idカラムには購入者のuser_idを入れることとし、出品時にはseller_idカラムのみ、購入時には両カラムにユーザーのidが入った状態となる。


これらにアソシエーションを組むことで、以下のように商品売買の状況を判断する。
***
### bought_items（購入した商品）
購入ユーザーのidが、buyer_idとして保存されているもの
### sales_items（出品中の商品）
buyer_idがnullの商品のうち、出品ユーザーのidがseller_idとして保存されているもの
### sold_items（売却済みの商品）
buyer_idがnot nullの商品のうち、ログインユーザーのidがseller_idとして保存されているもの
***

なお、本ブランチにおいてはテストコードの追記は行わない。

# Why
ユーザー情報に紐付いた商品の売買状況は、フリーマーケットアプリケーションにおける必須の情報であるため。
また、購入された商品が出品状態になることを防ぐため。