### PR TITLE
ユーザー新規登録機能、ログイン機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ group :development, :test do
   gem 'capistrano-rails'
   gem 'capistrano3-unicorn'
   gem 'capistrano-rails-console'
+  gem 'rspec-rails', '~> 4.0.0.beta2'
+  gem 'factory_bot_rails'
 end
 
 group :development do
@@ -75,9 +77,6 @@ gem 'mini_magick'
 gem 'fog-aws'
 
 gem 'rails-i18n', '~> 6.0.0'
-
-gem 'rspec-rails', '~> 4.0.0.beta2'
-gem 'factory_bot_rails'
 
 gem 'jquery-rails'
 gem 'font-awesome-sass'

--- a/Gemfile
+++ b/Gemfile
@@ -40,8 +40,6 @@ group :development, :test do
   gem 'capistrano-rails'
   gem 'capistrano3-unicorn'
   gem 'capistrano-rails-console'
-  gem 'rspec-rails', '~> 4.0.0.beta2'
-  gem 'factory_bot_rails'
 end
 
 group :development do

--- a/README.md
+++ b/README.md
@@ -6,27 +6,19 @@
 |nickname|string|null: false|
 |email|string|null: false, unique: true|
 |password|string|null: false|
+|last_name|string|null:false|
+|first_name|string|null:false|
+|last_name_kana|string|null: false|
+|first_name_kana|string|null: false|
+|birth_year|year(4)|null:false|
+|birth_month|integer(2)|null:false|
+|birth_day|integer(2)|null:false|
 ### Association
 - has_many :buyed_items, foreign_key: "buyer_id", class_name: "items"
 - has_many :saling_items, foreign_key: "seller_id", class_name: "items"
 - has_many :sold_items, foreign_key: "seller_id", class_name: "items"
-- has_one :profile, dependent: :destroy
 - has_one :credit_card, dependent: :destroy
 - has_one :address, dependent: :destroy
-
-## Profilesテーブル
-|Column|Type|Options|
-|------|----|-------|
-|first_name|string|null:false|
-|last_name|string|null:false|
-|first_name_kana|string|null: false|
-|last_name_kana|string|null: false|
-|birth_year|year(4)|null:false|
-|birth_month|integer(2)|null:false|
-|birth_day|integer(2)|null:false|
-|user_id|references|null:false, foreign_key:true|
-### Association
-- belongs_to :user
 
 ## Credit_cardsテーブル
 |Column|Type|Options|
@@ -40,16 +32,16 @@
 ## Addressテーブル
 |Column|Type|Options|
 |------|----|-------|
-|send_first_name|string|null: false|
 |send_last_name|string|null: false|
-|send_first_name_kana|string|null: false|
+|send_first_name|string|null: false|
 |send_last_name_kana|string|null: false|
-|postal_code|integer(7)|null: false|
-|prefecture|integer|null: false|
+|send_first_name_kana|string|null: false|
+|postal_code|string|null: false|
+|prefecture_id|integer|null: false|
 |city|string|null:false|
 |address|string|null:false|
 |build_name|string||
-|phone_number|integer||
+|phone_number|string||
 |user_id|references|null:false, foreign_key:true|
 ### Association
 - belongs_to :user

--- a/app/assets/javascripts/user_registration.js
+++ b/app/assets/javascripts/user_registration.js
@@ -1,0 +1,11 @@
+$(function() {
+  $('#passcheck').change(function(){
+    if ($(this).prop('checked')) {
+      $('#js-password').attr('type','text');
+      $('#js-password_confirmation').attr('type','text');
+    } else {
+      $('#js-password').attr('type','password');
+      $('#js-password_confirmation').attr('type','password');
+    }
+  });
+});

--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -52,8 +52,8 @@
         margin-right: 30px;
         }
       }
-    ul.header-bottom__right {
-      li {
+    .header-bottom__right {
+      a {
         display: inline-block;
         margin-left: 30px;
       }

--- a/app/assets/stylesheets/_logout.scss
+++ b/app/assets/stylesheets/_logout.scss
@@ -13,8 +13,6 @@
       .logout-page__btn {
         max-width: 320px;
         margin: 0 auto;
-        .btn-lightblue {
-        }
         .btn-default {
           margin: 40px 0 0;
           background: #3ccace;

--- a/app/assets/stylesheets/_logout.scss
+++ b/app/assets/stylesheets/_logout.scss
@@ -1,7 +1,12 @@
 .logout-page {
   background-color: #f5f5f5;
   width: 100%;
+  height: 800px;
+  padding: 40px;
   &__content {
+    height: 250px;
+    width: 700px;
+    margin: 0 auto;
     background: #fff;
     .logout-page__form {
       padding: 64px;
@@ -9,12 +14,13 @@
         max-width: 320px;
         margin: 0 auto;
         .btn-lightblue {
+        }
+        .btn-default {
           margin: 40px 0 0;
           background: #3ccace;
           border: 1px solid #3ccace;
+          border-radius: 4px;
           color: #fff;
-        }
-        .btn-default {
           display: block;
           width: 100%;
           line-height: 48px;
@@ -22,6 +28,7 @@
           border: 1px solid;
           cursor: pointer;
           text-align: center;
+          text-decoration: none;
         }
       }
     }

--- a/app/assets/stylesheets/_user.scss
+++ b/app/assets/stylesheets/_user.scss
@@ -113,6 +113,9 @@ $furima-color: #3ccace;
     font-size: 16px;
     font-weight: bold;
   }
+  p {
+    font-size: 14px
+  }
   label {
     font-weight: 600;
   }
@@ -139,7 +142,7 @@ $furima-color: #3ccace;
     }
   }
   &__InputBoxHalf {
-    width: calc(50% - 6px);
+    width: 171.5px;
     margin-right: 8px;
     padding: 10px 15px;
     @include form-box;
@@ -153,6 +156,7 @@ $furima-color: #3ccace;
 
 .FormInfoText {
   margin-top: 8px;
+  font-size: 14px;
   color: #888;
 }
 
@@ -184,5 +188,14 @@ $furima-color: #3ccace;
     &:hover {
       @include hover-underline
     }
+  }
+}
+
+.alert.alert-warning {
+  padding: 10px 0;
+  li {
+    font-size: 14px;
+    text-align: left;
+    color: #ff0211;
   }
 }

--- a/app/assets/stylesheets/_user.scss
+++ b/app/assets/stylesheets/_user.scss
@@ -54,6 +54,9 @@ $furima-color: #3ccace;
     padding: 40px 65px;
     border-bottom: 1px solid $lightgray;
     text-align: center;
+    p {
+      font-size: 14px;
+    }
     .SignUpBtn {
       display: block;
       width: 100%;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,7 @@
 @import "users";
 @import "header";
 @import "footer";
+@import "logout";
 
 input:focus, textarea:focus, select:focus {
   background-color: #fff;

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -63,7 +63,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   protected
 
   def address_params
-    params.require(:address).permit(:send_first_name, :send_last_name, :send_first_name_kana, :send_last_name_kana, :postal_code, :prefecture_id, :city, :address, :build_name, :phone_number)
+    params.require(:address).permit(:send_last_name, :send_first_name, :send_last_name_kana, :send_first_name_kana, :postal_code, :prefecture_id, :city, :address, :build_name, :phone_number)
   end
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,8 @@
 class UsersController < ApplicationController
   def show
   end
+  
+  def logout
+  end
+
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,6 +1,18 @@
 class Address < ApplicationRecord
   belongs_to :user, optional: true
-  validates :send_first_name, :send_last_name, :send_first_name_kana, :send_last_name_kana, :postal_code, :prefecture_id, :city, :address ,presence: true
+
+  validates :send_last_name, :send_first_name,  presence: true,
+                                                format: {
+                                                with: /\A(?:\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々])+\z/,
+                                                message: "は全角で入力して下さい"
+                                                }
+validates :send_last_name_kana, :send_first_name_kana,  presence: true,
+                                                        format: {
+                                                        with: /\A[ァ-ヶー－]+\z/,
+                                                        message: "は全角カタカナで入力して下さい"
+                                                        }
+
+validates :postal_code, :prefecture_id, :city, :address ,presence: true
 
 
   extend ActiveHash::Associations::ActiveRecordExtensions

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,4 +1,9 @@
 class Address < ApplicationRecord
   belongs_to :user, optional: true
   validates :send_first_name, :send_last_name, :send_first_name_kana, :send_last_name_kana, :postal_code, :prefecture_id, :city, :address ,presence: true
+
+
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :prefecture
+
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -19,4 +19,5 @@ class Prefecture < ActiveHash::Base
                 {id: 46, name: '鹿児島県'}, {id: 47, name: '沖縄県'}
               ]
   has_many :items
+  has_many :addresses
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,20 +2,20 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-  :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable
   
   validates :nickname, presence: true
   validates :password, length: { minimum: 7 }
   validates :last_name, :first_name,  presence: true,
-  format: {
-    with: /\A(?:\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々])+\z/,
-    message: "は全角で入力して下さい"
-  }
+                                      format: {
+                                        with: /\A(?:\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々])+\z/,
+                                        message: "は全角で入力して下さい"
+                                      }
   validates :last_name_kana, :first_name_kana,  presence: true,
-  format: {
-    with: /\A[ァ-ヶー－]+\z/,
-    message: "は全角カタカナで入力して下さい"
-  }
+                                                format: {
+                                                  with: /\A[ァ-ヶー－]+\z/,
+                                                  message: "は全角カタカナで入力して下さい"
+                                                }
   validates :birth_year, :birth_month, :birth_day, presence: true
 
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,11 +6,17 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  validates :nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birth_year, :birth_month, :birth_day ,presence: true
-
   validates :nickname, presence: true
-  validates :password, presence: true, length: { minimum: 7 }
-  validates :last_name, :first_name, presence: true
-  validates :last_name_kana, :first_name_kana, presence: true
+  validates :password, length: { minimum: 7 }
+  validates :last_name, :first_name,  presence: true,
+                                                format: {
+                                                with: /\A(?:\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々])+\z/,
+                                                message: "は全角で入力して下さい"
+                                                }
+  validates :last_name_kana, :first_name_kana,  presence: true,
+                                                format: {
+                                                with: /\A[ァ-ヶー－]+\z/,
+                                                message: "は全角カタカナで入力して下さい"
+                                                }
   validates :birth_year, :birth_month, :birth_day, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,16 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  has_one :address, dependent: :destroy
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
   validates :nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birth_year, :birth_month, :birth_day ,presence: true
-  has_one :address, dependent: :destroy
+
+  validates :nickname, presence: true
+  validates :password, presence: true, length: { minimum: 7 }
+  validates :last_name, :first_name, presence: true
+  validates :last_name_kana, :first_name_kana, presence: true
+  validates :birth_year, :birth_month, :birth_day, presence: true
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -5,7 +5,6 @@
       会員情報の登録
     .SignUpForm
       = form_with model: @user, url: user_registration_path, id: 'new_user', class: 'new_user', local: true do |f|
-        = render "devise/shared/error_messages", resource: @user
         .FormContent
           .Field
             = f.label :ニックネーム
@@ -13,12 +12,14 @@
               必須
             %br/
             = f.text_field :nickname, autofocus: true, placeholder: "例)フリマ太郎", class: "Field__InputBox"
+            = render "devise/shared/error_messages", model: @user, attribute: :nickname
           .Field
             = f.label :メールアドレス
             %span.RequiredItem
               必須
             %br/
             = f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "PC・携帯どちらでも可", class: "Field__InputBox"
+            = render "devise/shared/error_messages", model: @user, attribute: :email
           .Field
             = f.label :パスワード
             %span.RequiredItem
@@ -27,6 +28,7 @@
             = f.password_field :password, autocomplete: "new-password", placeholder: "7文字以上の半角英数字", class: "Field__InputBox"
             %p.FormInfoText
               ※ 英字と数字の両方を含めて設定してください
+            = render "devise/shared/error_messages", model: @user, attribute: :password
           .Field
             = f.label :パスワード（確認用）
             %span.RequiredItem
@@ -36,6 +38,7 @@
           .ShowPassword
             = f.check_box class: "ShowPassword__CheckBox"
             = f.label :パスワードを表示する, class: "ShowPassword__Text"
+            = render "devise/shared/error_messages", model: @user, attribute: :password_confirmation
           .Field
             %h3
               本人確認
@@ -49,6 +52,8 @@
             .Field__MultiInputBox
               = f.text_field :last_name, autocomplete: "true", placeholder: "例)山田", class: "Field__InputBoxHalf"
               = f.text_field :first_name, autocomplete: "true", placeholder: "例)太郎", class: "Field__InputBoxHalf"
+            = render "devise/shared/error_messages", model: @user, attribute: :last_name
+            = render "devise/shared/error_messages", model: @user, attribute: :first_name
           .Field
             = f.label :お名前カナ（全角）
             %span.RequiredItem
@@ -57,6 +62,8 @@
             .Field__MultiInputBox
               = f.text_field :last_name_kana, autocomplete: "true", placeholder: "例)ヤマダ", class: "Field__InputBoxHalf"
               = f.text_field :first_name_kana, autocomplete: "true", placeholder: "例)タロウ", class: "Field__InputBoxHalf"
+            = render "devise/shared/error_messages", model: @user, attribute: :last_name_kana
+            = render "devise/shared/error_messages", model: @user, attribute: :first_name_kana
           .Field
             = f.label :生年月日
             %span.RequiredItem
@@ -72,6 +79,9 @@
               = f.text_field :birth_day, autocomplete: "true", class: "Field__SelectBox"
               %span
                 日
+            = render "devise/shared/error_messages", model: @user, attribute: :birth_year
+            = render "devise/shared/error_messages", model: @user, attribute: :birth_month
+            = render "devise/shared/error_messages", model: @user, attribute: :birth_day
           %p.FormInfoText
             ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
           .Actions

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -25,7 +25,7 @@
             %span.RequiredItem
               必須
             %br/
-            = f.password_field :password, autocomplete: "new-password", placeholder: "7文字以上の半角英数字", class: "Field__InputBox"
+            = f.password_field :password, autocomplete: "new-password", placeholder: "7文字以上の半角英数字", class: "Field__InputBox", id: "js-password"
             %p.FormInfoText
               ※ 英字と数字の両方を含めて設定してください
             = render "devise/shared/error_messages", model: @user, attribute: :password
@@ -34,9 +34,9 @@
             %span.RequiredItem
               必須
             %br/
-            = f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "もう一度入力してください", class: "Field__InputBox"
+            = f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "もう一度入力してください", class: "Field__InputBox", id: "js-password_confirmation"
           .ShowPassword
-            = f.check_box class: "ShowPassword__CheckBox"
+            = check_box_tag :passcheck, class: "ShowPassword__CheckBox"
             = f.label :パスワードを表示する, class: "ShowPassword__Text"
             = render "devise/shared/error_messages", model: @user, attribute: :password_confirmation
           .Field

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -47,16 +47,16 @@
               必須
             %br/
             .Field__MultiInputBox
-              = f.text_field :first_name, autocomplete: "true", placeholder: "例)山田", class: "Field__InputBoxHalf"
-              = f.text_field :last_name, autocomplete: "true", placeholder: "例)太郎", class: "Field__InputBoxHalf"
+              = f.text_field :last_name, autocomplete: "true", placeholder: "例)山田", class: "Field__InputBoxHalf"
+              = f.text_field :first_name, autocomplete: "true", placeholder: "例)太郎", class: "Field__InputBoxHalf"
           .Field
             = f.label :お名前カナ（全角）
             %span.RequiredItem
               必須
             %br/
             .Field__MultiInputBox
-              = f.text_field :first_name_kana, autocomplete: "true", placeholder: "例)ヤマダ", class: "Field__InputBoxHalf"
-              = f.text_field :last_name_kana, autocomplete: "true", placeholder: "例)タロウ", class: "Field__InputBoxHalf"
+              = f.text_field :last_name_kana, autocomplete: "true", placeholder: "例)ヤマダ", class: "Field__InputBoxHalf"
+              = f.text_field :first_name_kana, autocomplete: "true", placeholder: "例)タロウ", class: "Field__InputBoxHalf"
           .Field
             = f.label :生年月日
             %span.RequiredItem

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -13,16 +13,16 @@
               必須
             %br/
             .Field__MultiInputBox
-              = f.text_field :send_first_name, autocomplete: "true", placeholder: "例)山田", class: "Field__InputBoxHalf"
-              = f.text_field :send_last_name, autocomplete: "true", placeholder: "例)太郎", class: "Field__InputBoxHalf"
+              = f.text_field :send_last_name, autocomplete: "true", placeholder: "例)山田", class: "Field__InputBoxHalf"
+              = f.text_field :send_first_name, autocomplete: "true", placeholder: "例)太郎", class: "Field__InputBoxHalf"
           .Field
             = f.label :送付先氏名カナ（全角）
             %span.RequiredItem
               必須
             %br/
             .Field__MultiInputBox
-              = f.text_field :send_first_name_kana, autocomplete: "true", placeholder: "例)ヤマダ", class: "Field__InputBoxHalf"
-              = f.text_field :send_last_name_kana, autocomplete: "true", placeholder: "例)タロウ", class: "Field__InputBoxHalf"
+              = f.text_field :send_last_name_kana, autocomplete: "true", placeholder: "例)ヤマダ", class: "Field__InputBoxHalf"
+              = f.text_field :send_first_name_kana, autocomplete: "true", placeholder: "例)タロウ", class: "Field__InputBoxHalf"
           .Field
             = f.label :郵便番号
             %span.RequiredItem

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -34,7 +34,7 @@
             %span.RequiredItem
               必須
             %br/
-            = f.text_field :prefecture_id, autofocus: true, class: "Field__InputBox"
+            = f.collection_select :prefecture_id, Prefecture.all, :id, :name, {prompt: "選択してください"}, {class: "Field__InputBox"}
           .Field
             = f.label :市区町村
             %span.RequiredItem

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -5,7 +5,6 @@
       お届け先情報の登録
     .SignUpForm
       = form_with model: @address, local: true do |f|
-        = render "devise/shared/error_messages", resource: @address
         .FormContent
           .Field
             = f.label :送付先氏名（全角）
@@ -15,6 +14,8 @@
             .Field__MultiInputBox
               = f.text_field :send_last_name, autocomplete: "true", placeholder: "例)山田", class: "Field__InputBoxHalf"
               = f.text_field :send_first_name, autocomplete: "true", placeholder: "例)太郎", class: "Field__InputBoxHalf"
+            = render "devise/shared/error_messages", model: @address, attribute: :send_last_name
+            = render "devise/shared/error_messages", model: @address, attribute: :send_first_name
           .Field
             = f.label :送付先氏名カナ（全角）
             %span.RequiredItem
@@ -23,42 +24,50 @@
             .Field__MultiInputBox
               = f.text_field :send_last_name_kana, autocomplete: "true", placeholder: "例)ヤマダ", class: "Field__InputBoxHalf"
               = f.text_field :send_first_name_kana, autocomplete: "true", placeholder: "例)タロウ", class: "Field__InputBoxHalf"
+            = render "devise/shared/error_messages", model: @address, attribute: :send_last_name_kana
+            = render "devise/shared/error_messages", model: @address, attribute: :send_first_name_kana
           .Field
             = f.label :郵便番号
             %span.RequiredItem
               必須
             %br/
             = f.text_field :postal_code, autofocus: true, placeholder: "例)1234567", class: "Field__InputBox"
+            = render "devise/shared/error_messages", model: @address, attribute: :postal_code
           .Field
             = f.label :都道府県
             %span.RequiredItem
               必須
             %br/
             = f.collection_select :prefecture_id, Prefecture.all, :id, :name, {prompt: "選択してください"}, {class: "Field__InputBox"}
+            = render "devise/shared/error_messages", model: @address, attribute: :prefecture_id
           .Field
             = f.label :市区町村
             %span.RequiredItem
               必須
             %br/
             = f.text_field :city, autofocus: true, placeholder: "例)横浜市緑区", class: "Field__InputBox"
+            = render "devise/shared/error_messages", model: @address, attribute: :city
           .Field
             = f.label :番地
             %span.RequiredItem
               必須
             %br/
             = f.text_field :address, autofocus: true, placeholder: "例)青山1-1-1", class: "Field__InputBox"
+            = render "devise/shared/error_messages", model: @address, attribute: :address
           .Field
             = f.label :建物名と部屋番号
             %span.AnyItem
               任意
             %br/
             = f.text_field :build_name, autofocus: true, placeholder: "例)柳ビル103", class: "Field__InputBox"
+            = render "devise/shared/error_messages", model: @address, attribute: :build_name
           .Field
             = f.label :お届け先の電話番号
             %span.AnyItem
               任意
             %br/
             = f.text_field :phone_number, autofocus: true, placeholder: "例)09012345678", class: "Field__InputBox"
+            = render "devise/shared/error_messages", model: @address, attribute: :phone_number
           .Actions
             = f.submit "新規登録", class: "ActionBtn"
   = render partial: 'devise/shared/footer'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -6,11 +6,12 @@
       = link_to '新規会員登録', new_user_registration_path, class: "SignUpBtn"
     .LogInForm
       = form_with model: @user, url: user_session_path, id: 'new_user', class: 'new_user', local: true do |f|
-        = render "devise/shared/error_messages", resource: @user
         .Field
           = f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス", class: "Field__InputBox"
+          = render "devise/shared/error_messages", model: @user, attribute: :email
         .Field
           = f.password_field :password, autocomplete: "current-password", placeholder: "パスワード", class: "Field__InputBox"
+          = render "devise/shared/error_messages", model: @user, attribute: :password
         .Actions
           = f.submit "ログイン", class: "ActionBtn"
       = link_to 'パスワードをお忘れの方', new_password_path(resource_name), class: "ForgetPassword"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -8,10 +8,8 @@
       = form_with model: @user, url: user_session_path, id: 'new_user', class: 'new_user', local: true do |f|
         .Field
           = f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス", class: "Field__InputBox"
-          = render "devise/shared/error_messages", model: @user, attribute: :email
         .Field
           = f.password_field :password, autocomplete: "current-password", placeholder: "パスワード", class: "Field__InputBox"
-          = render "devise/shared/error_messages", model: @user, attribute: :password
         .Actions
           = f.submit "ログイン", class: "ActionBtn"
       = link_to 'パスワードをお忘れの方', new_password_path(resource_name), class: "ForgetPassword"

--- a/app/views/devise/shared/_error_messages.html.haml
+++ b/app/views/devise/shared/_error_messages.html.haml
@@ -1,9 +1,5 @@
-- if resource.errors.any?
-  #error_explanation
-    %h2
-      = I18n.t("errors.messages.not_saved",                 |
-        count: resource.errors.count,                       |
-        resource: resource.class.model_name.human.downcase) |
+- if model.errors.any?
+  .alert.alert-warning
     %ul
-      - resource.errors.full_messages.each do |message|
+      - model.errors.full_messages_for(attribute).each do |message|
         %li= message

--- a/app/views/items/_header.html.haml
+++ b/app/views/items/_header.html.haml
@@ -17,4 +17,4 @@
         = link_to "マイページ", "/users/:id"
       - else
         = link_to "ログイン", new_user_session_path, class: "post"
-        = link_to "新規登録", new_user_registration_path, class: "post"
+        = link_to "新規登録", new_user_registration_path, class: "post", data: {"turbolinks": false}

--- a/app/views/items/_header.html.haml
+++ b/app/views/items/_header.html.haml
@@ -1,7 +1,7 @@
 .header
   .header-top
     .header-top__logo
-      = image_tag 'material/logo/logo.png' , alt: '使用例の画像', :size => '140x40'
+      = link_to image_tag('material/logo/logo.png' , alt: '使用例の画像', :size => '140x40'), root_path
     %form.header-top__search-bar
       %input.item-search{name: "keyword", placeholder: "キーワードから探す", type: "search", value: ""}
       .search-icon
@@ -12,8 +12,10 @@
         =link_to "カテゴリーから探す"
       %li 
         =link_to "ブランドから探す"
-    %ul.header-bottom__right
-      %li 
-        =link_to "ログイン"
-      %li
-        =link_to "新規会員登録"
+    .header-bottom__right
+      - if user_signed_in?
+        = link_to "マイページ", "/users/:id"
+        = link_to "ログアウト", destroy_user_session_path, method: :delete
+      - else
+        = link_to "ログイン", new_user_session_path, class: "post"
+        = link_to "新規登録", new_user_registration_path, class: "post"

--- a/app/views/items/_header.html.haml
+++ b/app/views/items/_header.html.haml
@@ -15,7 +15,6 @@
     .header-bottom__right
       - if user_signed_in?
         = link_to "マイページ", "/users/:id"
-        = link_to "ログアウト", destroy_user_session_path, method: :delete
       - else
         = link_to "ログイン", new_user_session_path, class: "post"
         = link_to "新規登録", new_user_registration_path, class: "post"

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -1,6 +1,6 @@
 %main
   .logout-page
     .logout-page__content
-      %form.logout-page__form{action: "/users/sign_out", :method => "delete"}
+      .logout-page__form
         .logout-page__btn
-          %button.btn-default.btn-lightblue{type: "submit"} ログアウト
+        = link_to "ログアウト", destroy_user_session_path, method: :delete

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -1,6 +1,11 @@
+.wrapper
+  = render partial: 'items/header'
+
 %main
   .logout-page
     .logout-page__content
       .logout-page__form
         .logout-page__btn
-        = link_to "ログアウト", destroy_user_session_path, method: :delete
+          = link_to "ログアウト", destroy_user_session_path, method: :delete, class: "btn-default"
+
+= render partial: 'items/footer'

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -47,7 +47,7 @@
       %li
         = link_to "電話番号の確認"
       %li
-        = link_to "ログアウト"
+        = link_to "ログアウト", logout_user_path
 
   .main-content
     .main-content__photo

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -2,6 +2,7 @@ ja:
   activerecord:
     models:
       item: 商品
+      user: ユーザー
     attributes:
       item:
         category: カテゴリー
@@ -13,3 +14,15 @@ ja:
         postage_id: 配送料の負担
         shipping_date_id: 発送までの日数
         images: 写真
+      user:
+        nickname: ニックネーム 
+        email: メールアドレス
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        last_name: お名前（名字）
+        first_name: お名前（名前）
+        last_name_kana: お名前カナ（名字）
+        first_name_kana: お名前カナ（名前）
+        birth_year: 生年月日（年）
+        birth_month: 生年月日（月）
+        birth_day: 生年月日（日）

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       item: 商品
       user: ユーザー
+      address: 住所
     attributes:
       item:
         category: カテゴリー
@@ -26,3 +27,14 @@ ja:
         birth_year: 生年月日（年）
         birth_month: 生年月日（月）
         birth_day: 生年月日（日）
+      address:
+        send_last_name: 送付先氏名（名字）
+        send_first_name: 送付先氏名（名前）
+        send_last_name_kana: 送付先氏名カナ（名字）
+        send_first_name_kana: 送付先氏名カナ（名前）
+        postal_code: 郵便番号
+        prefecture_id: 都道府県
+        city: 市区町村
+        address: 番地
+        build_name: 建物名と部屋番号
+        phone_number: お届け先の電話番号

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,10 @@ Rails.application.routes.draw do
       get 'buy'
     end
   end
-  resources :users, only: :show
+  resources :users, only: :show do
+    member do
+      get 'logout'
+    end
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,10 +25,9 @@ Rails.application.routes.draw do
   end
 
   resources :categories, only: [:index,]
-  resources :users, only: [:show]
   resources :cards, only: [:new]
 
-  resources :users, only: :show do
+  resources :users, only: [:show] do
     member do
       get 'logout'
     end

--- a/db/migrate/20200807075238_devise_create_users.rb
+++ b/db/migrate/20200807075238_devise_create_users.rb
@@ -7,10 +7,10 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.0]
       t.string :nickname,           null: false
       t.string :email,              null: false, default: ""
       t.string :encrypted_password, null: false, default: ""
-      t.string :first_name,         null: false
       t.string :last_name,          null: false
-      t.string :first_name_kana,    null: false
+      t.string :first_name,         null: false
       t.string :last_name_kana,     null: false
+      t.string :first_name_kana,    null: false
       t.integer :birth_year,        null: false
       t.integer :birth_month,       null: false
       t.integer :birth_day,         null: false

--- a/db/migrate/20200812151954_create_addresses.rb
+++ b/db/migrate/20200812151954_create_addresses.rb
@@ -2,10 +2,10 @@ class CreateAddresses < ActiveRecord::Migration[6.0]
   def change
     create_table :addresses do |t|
       t.references :user,                null: false, foreign_key: true
-      t.string :send_first_name,         null: false
       t.string :send_last_name,          null: false
-      t.string :send_first_name_kana,    null: false
+      t.string :send_first_name,         null: false
       t.string :send_last_name_kana,     null: false
+      t.string :send_first_name_kana,    null: false
       t.integer :postal_code,            null: false
       t.integer :prefecture,             null: false
       t.string :city,                    null: false

--- a/db/migrate/20200812151954_create_addresses.rb
+++ b/db/migrate/20200812151954_create_addresses.rb
@@ -6,7 +6,7 @@ class CreateAddresses < ActiveRecord::Migration[6.0]
       t.string :send_first_name,         null: false
       t.string :send_last_name_kana,     null: false
       t.string :send_first_name_kana,    null: false
-      t.integer :postal_code,            null: false
+      t.string :postal_code,            null: false
       t.integer :prefecture,             null: false
       t.string :city,                    null: false
       t.string :address,                 null: false

--- a/db/migrate/20200812151954_create_addresses.rb
+++ b/db/migrate/20200812151954_create_addresses.rb
@@ -11,7 +11,7 @@ class CreateAddresses < ActiveRecord::Migration[6.0]
       t.string :city,                    null: false
       t.string :address,                 null: false
       t.string :build_name
-      t.integer :phone_number
+      t.string :phone_number
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,7 +23,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_003200) do
     t.string "city", null: false
     t.string "address", null: false
     t.string "build_name"
-    t.integer "phone_number"
+    t.string "phone_number"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_addresses_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,10 +14,10 @@ ActiveRecord::Schema.define(version: 2020_08_14_003200) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.string "send_first_name", null: false
     t.string "send_last_name", null: false
-    t.string "send_first_name_kana", null: false
+    t.string "send_first_name", null: false
     t.string "send_last_name_kana", null: false
+    t.string "send_first_name_kana", null: false
     t.integer "postal_code", null: false
     t.integer "prefecture_id", null: false
     t.string "city", null: false
@@ -64,10 +64,10 @@ ActiveRecord::Schema.define(version: 2020_08_14_003200) do
     t.string "nickname", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
-    t.string "first_name", null: false
     t.string "last_name", null: false
-    t.string "first_name_kana", null: false
+    t.string "first_name", null: false
     t.string "last_name_kana", null: false
+    t.string "first_name_kana", null: false
     t.integer "birth_year", null: false
     t.integer "birth_month", null: false
     t.integer "birth_day", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_003200) do
     t.string "send_first_name", null: false
     t.string "send_last_name_kana", null: false
     t.string "send_first_name_kana", null: false
-    t.integer "postal_code", null: false
+    t.string "postal_code", null: false
     t.integer "prefecture_id", null: false
     t.string "city", null: false
     t.string "address", null: false

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  
+  factory :address do
+    send_last_name             {"鈴木"}
+    send_first_name            {"太郎"}
+    send_last_name_kana        {"スズキ"}
+    send_first_name_kana       {"タロウ"}
+    postal_code                {1234567}
+    prefecture_id              {1}
+    city                       {"横浜市緑区"}
+    address                    {"青山1-1-1"}
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,11 +3,11 @@ FactoryBot.define do
   factory :user do
     nickname              {"sample name"}
     email                 {"sample@gmail.com"}
-    password              {"0000000"}
-    password_confirmation {"0000000"}
-    last_name             {"山田"}
+    password              {"00000000"}
+    password_confirmation {"00000000"}
+    last_name             {"鈴木"}
     first_name            {"太郎"}
-    last_name_kana        {"ヤマダ"}
+    last_name_kana        {"スズキ"}
     first_name_kana       {"タロウ"}
     birth_year            {"0000"}
     birth_month           {"00"}

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  
+  factory :user do
+    nickname              {"sample name"}
+    email                 {"sample@gmail.com"}
+    password              {"0000000"}
+    password_confirmation {"0000000"}
+    last_name             {"山田"}
+    first_name            {"太郎"}
+    last_name_kana        {"ヤマダ"}
+    first_name_kana       {"タロウ"}
+    birth_year            {"0000"}
+    birth_month           {"00"}
+    birth_day             {"00"}
+  end
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,165 @@
+require 'rails_helper'
+
+RSpec.describe Address do
+  describe '#create_address' do
+
+    context 'can save' do
+      it '必須項目が入力されている場合は登録できること' do
+        address = build(:address)
+        expect(address).to be_valid
+      end
+      
+      it '送付先氏名の名字が全角（漢字）である場合は登録できること' do
+        address = build(:address, send_last_name: "山田")
+        expect(address).to be_valid
+      end
+      
+      it '送付先氏名の名字が全角（ひらがな）である場合は登録できること' do
+        address = build(:address, send_last_name: "やまだ")
+        expect(address).to be_valid
+      end
+      
+      it '送付先氏名の名字が全角（カタカナ）である場合は登録できること' do
+        address = build(:address, send_last_name: "ヤマダ")
+        expect(address).to be_valid
+      end
+      
+      it '送付先氏名の名前が全角（漢字）である場合は登録できること' do
+        address = build(:address, send_first_name: "次郎")
+        expect(address).to be_valid
+      end
+
+      it '送付先氏名の名前が全角（ひらがな）である場合は登録できること' do
+        address = build(:address, send_first_name: "じろう")
+        expect(address).to be_valid
+      end
+
+      it '送付先氏名の名前が全角（カタカナ）である場合は登録できること' do
+        address = build(:address, send_first_name: "ジロウ")
+        expect(address).to be_valid
+      end
+
+      it '送付先氏名の名字のふりがなが全角（カタカナ）である場合は登録できること' do
+        address = build(:address, send_last_name_kana: "ヤマダ")
+        expect(address).to be_valid
+      end
+
+      it '送付先氏名の名前のふりがなが全角（カタカナ）である場合は登録できること' do
+        address = build(:address, send_first_name_kana: "ジロウ")
+        expect(address).to be_valid
+      end
+      
+      it '建物名と部屋番号が登録できること' do
+        address = build(:address, build_name: "柳ビル103")
+        expect(address).to be_valid
+      end
+      
+      it 'お届け先の電話番号登録できること' do
+        address = build(:address, phone_number: "09012345678")
+        expect(address).to be_valid
+      end
+
+    end
+
+    context 'can not save' do
+      it '送付先氏名の名字が入力されていない場合は登録できないこと' do
+        address = build(:address, send_last_name: "")
+        address.valid?
+        expect(address.errors[:send_last_name]).to include("を入力してください")
+      end
+      
+      it '送付先氏名の名字が半角カタカナの場合は登録できないこと' do
+        address = build(:address, send_last_name: "ﾔﾏﾀﾞ")
+        address.valid?
+        expect(address.errors[:send_last_name]).to include("は全角で入力して下さい")
+      end
+
+      it '送付先氏名の名前が入力されていない場合は登録できないこと' do
+        address = build(:address, send_first_name: "")
+        address.valid?
+        expect(address.errors[:send_first_name]).to include("を入力してください")
+      end
+      
+      it '送付先氏名の名前が半角カタカナの場合は登録できないこと' do
+        address = build(:address, send_first_name: "ｼﾞﾛｳ")
+        address.valid?
+        expect(address.errors[:send_first_name]).to include("は全角で入力して下さい")
+      end
+      
+      it '送付先氏名の名字のふりがなが入力されていない場合は登録できないこと' do
+        address = build(:address, send_last_name_kana: "")
+        address.valid?
+        expect(address.errors[:send_last_name_kana]).to include("を入力してください")
+      end
+      
+      it '送付先氏名の名字のふりがなが全角（漢字）の場合は登録できないこと' do
+        address = build(:address, send_last_name_kana: "山田")
+        address.valid?
+        expect(address.errors[:send_last_name_kana]).to include("は全角カタカナで入力して下さい")
+      end
+      
+      it '送付先氏名の名字のふりがなが全角（ひらがな）の場合は登録できないこと' do
+        address = build(:address, send_last_name_kana: "やまだ")
+        address.valid?
+        expect(address.errors[:send_last_name_kana]).to include("は全角カタカナで入力して下さい")
+      end
+      
+      it '送付先氏名の名字のふりがなが半角カタカナの場合は登録できないこと' do
+        address = build(:address, send_last_name_kana: "ﾔﾏﾀﾞ")
+        address.valid?
+        expect(address.errors[:send_last_name_kana]).to include("は全角カタカナで入力して下さい")
+      end
+      
+      it '送付先氏名の名前のふりがなが入力されていない場合は登録できないこと' do
+        address = build(:address, send_first_name_kana: "")
+        address.valid?
+        expect(address.errors[:send_first_name_kana]).to include("を入力してください")
+      end
+      
+      it '送付先氏名の名前のふりがなが全角（漢字）の場合は登録できないこと' do
+        address = build(:address, send_first_name_kana: "次郎")
+        address.valid?
+        expect(address.errors[:send_first_name_kana]).to include("は全角カタカナで入力して下さい")
+      end
+      
+      it '送付先氏名の名前のふりがなが全角（ひらがな）の場合は登録できないこと' do
+        address = build(:address, send_first_name_kana: "じろう")
+        address.valid?
+        expect(address.errors[:send_first_name_kana]).to include("は全角カタカナで入力して下さい")
+      end
+      
+      it '送付先氏名の名前のふりがなが半角カタカナの場合は登録できないこと' do
+        address = build(:address, send_first_name_kana: "ｼﾞﾛｳ")
+        address.valid?
+        expect(address.errors[:send_first_name_kana]).to include("は全角カタカナで入力して下さい")
+      end
+
+      it '郵便番号が入力されていない場合は登録できないこと' do
+        address = build(:address, postal_code: "")
+        address.valid?
+        expect(address.errors[:postal_code]).to include("を入力してください")
+      end
+
+      it '都道府県が入力されていない場合は登録できないこと' do
+        address = build(:address, prefecture_id: "")
+        address.valid?
+        expect(address.errors[:prefecture_id]).to include("を入力してください")
+      end
+
+      it '市区町村が入力されていない場合は登録できないこと' do
+        address = build(:address, city: "")
+        address.valid?
+        expect(address.errors[:city]).to include("を入力してください")
+      end
+
+      it '番地が入力されていない場合は登録できないこと' do
+        address = build(:address, address: "")
+        address.valid?
+        expect(address.errors[:address]).to include("を入力してください")
+      end
+
+    end
+
+  end
+
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,8 +4,48 @@ RSpec.describe User do
   describe '#create' do
 
     context 'can save' do
-      it '必須項目が入力されていれば登録できること' do
+      it '必須項目が入力されている場合は登録できること' do
         user = build(:user)
+        expect(user).to be_valid
+      end
+      
+      it 'ユーザー本名の名字が全角（漢字）である場合は登録できること' do
+        user = build(:user, last_name: "山田")
+        expect(user).to be_valid
+      end
+      
+      it 'ユーザー本名の名字が全角（ひらがな）である場合は登録できること' do
+        user = build(:user, last_name: "やまだ")
+        expect(user).to be_valid
+      end
+      
+      it 'ユーザー本名の名字が全角（カタカナ）である場合は登録できること' do
+        user = build(:user, last_name: "ヤマダ")
+        expect(user).to be_valid
+      end
+      
+      it 'ユーザー本名の名前が全角（漢字）である場合は登録できること' do
+        user = build(:user, first_name: "次郎")
+        expect(user).to be_valid
+      end
+      
+      it 'ユーザー本名の名前が全角（ひらがな）である場合は登録できること' do
+        user = build(:user, first_name: "じろう")
+        expect(user).to be_valid
+      end
+      
+      it 'ユーザー本名の名前が全角（カタカナ）である場合は登録できること' do
+        user = build(:user, first_name: "ジロウ")
+        expect(user).to be_valid
+      end
+
+      it 'ユーザー本名の名字のふりがなが全角カタカナである場合は登録できること' do
+        user = build(:user, last_name_kana: "ヤマダ")
+        expect(user).to be_valid
+      end
+      
+      it 'ユーザー本名の名前のふりがなが全角カタカナである場合は登録できること' do
+        user = build(:user, first_name_kana: "ジロウ")
         expect(user).to be_valid
       end
 
@@ -13,24 +53,23 @@ RSpec.describe User do
         user = build(:user, password: "0000000", password_confirmation: "0000000")
         expect(user).to be_valid
       end
-      
-      
+
     end
-    
+
     context 'can not save' do
-      it 'ニックネームが必須であること' do
+      it 'ニックネームが入力されていない場合は登録できないこと' do
         user = build(:user, nickname: "")
         user.valid?
         expect(user.errors[:nickname]).to include("を入力してください")
       end
       
-      it 'メールアドレスが必須であること' do
+      it 'メールアドレスが入力されていない場合は登録できないこと' do
         user = build(:user, email: "")
         user.valid?
         expect(user.errors[:email]).to include("を入力してください")
       end
       
-      it 'パスワードが必須であること' do
+      it 'パスワードが入力されていない場合は登録できないこと' do
         user = build(:user, password: "")
         user.valid?
         expect(user.errors[:password]).to include("を入力してください")
@@ -42,49 +81,79 @@ RSpec.describe User do
         expect(user.errors[:password]).to include("は7文字以上で入力してください")
       end
       
-      it 'パスワードを2回入力する必要があること' do
+      it 'パスワードが入力されていても確認用のパスワードが入力されていない場合は登録できないこと' do
         user = build(:user, password_confirmation: "")
         user.valid?
         expect(user.errors[:password_confirmation]).to include("とPasswordの入力が一致しません")
       end
       
-      it 'ユーザー本名の名字が必須であること' do
+      it 'パスワードと確認用のパスワードが一致しない場合は登録できないこと' do
+        user = build(:user, password_confirmation: "1234567")
+        user.valid?
+        expect(user.errors[:password_confirmation]).to include("とPasswordの入力が一致しません")
+      end
+      
+      it 'ユーザー本名の名字が入力されていない場合は登録できないこと' do
         user = build(:user, last_name: "")
         user.valid?
         expect(user.errors[:last_name]).to include("を入力してください")
       end
       
-      it 'ユーザー本名の名前が必須であること' do
+      it 'ユーザー本名の名前が入力されていない場合は登録できないこと' do
         user = build(:user, first_name: "")
         user.valid?
         expect(user.errors[:first_name]).to include("を入力してください")
       end
       
-      it 'ユーザー本名の名字のふりがなが必須であること' do
+      it 'ユーザー本名の名字のふりがなが入力されていない場合は登録できないこと' do
         user = build(:user, last_name_kana: "")
         user.valid?
         expect(user.errors[:last_name_kana]).to include("を入力してください")
       end
       
-      it 'ユーザー本名の名前のふりがなが必須であること' do
+      it 'ユーザー本名の名前のふりがなが入力されていない場合は登録できないこと' do
         user = build(:user, first_name_kana: "")
         user.valid?
         expect(user.errors[:first_name_kana]).to include("を入力してください")
       end
+
+      it 'ユーザー本名の名字が半角の場合は登録できないこと' do
+        user = build(:user, last_name: "ﾔﾏﾀﾞ")
+        user.valid?
+        expect(user.errors[:last_name]).to include("は全角で入力して下さい")
+      end
       
-      it '生年月日の年が必須であること' do
+      it 'ユーザー本名の名前が半角の場合は登録できないこと' do
+        user = build(:user, first_name: "ｼﾞﾛｳ")
+        user.valid?
+        expect(user.errors[:first_name]).to include("は全角で入力して下さい")
+      end
+  
+      it 'ユーザー本名の名字のふりがなが全角カタカナでない場合は登録できないこと' do
+        user = build(:user, last_name_kana: "さとう")
+        user.valid?
+        expect(user.errors[:last_name_kana]).to include("は全角カタカナで入力して下さい")
+      end
+      
+      it 'ユーザー本名の名前のふりがなが全角カタカナでない場合は登録できないこと' do
+        user = build(:user, first_name_kana: "じろう")
+        user.valid?
+        expect(user.errors[:first_name_kana]).to include("は全角カタカナで入力して下さい")
+      end
+      
+      it '生年月日の年が入力されていない場合は登録できないこと' do
         user = build(:user, birth_year: "")
         user.valid?
         expect(user.errors[:birth_year]).to include("を入力してください")
       end
       
-      it '生年月日の月が必須であること' do
+      it '生年月日の月が入力されていない場合は登録できないこと' do
         user = build(:user, birth_month: "")
         user.valid?
         expect(user.errors[:birth_month]).to include("を入力してください")
       end
       
-      it '生年月日の日が必須であること' do
+      it '生年月日の日が入力されていない場合は登録できないこと' do
         user = build(:user, birth_day: "")
         user.valid?
         expect(user.errors[:birth_day]).to include("を入力してください")
@@ -93,4 +162,5 @@ RSpec.describe User do
     end
 
   end
+
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe User do
         user = build(:user)
         expect(user).to be_valid
       end
+
+      it 'パスワードが7文字以上であれば登録できること' do
+        user = build(:user, password: "0000000", password_confirmation: "0000000")
+        expect(user).to be_valid
+      end
       
       it 'ユーザー本名の名字が全角（漢字）である場合は登録できること' do
         user = build(:user, last_name: "山田")
@@ -39,18 +44,13 @@ RSpec.describe User do
         expect(user).to be_valid
       end
 
-      it 'ユーザー本名の名字のふりがなが全角カタカナである場合は登録できること' do
+      it 'ユーザー本名の名字のふりがなが全角（カタカナ）である場合は登録できること' do
         user = build(:user, last_name_kana: "ヤマダ")
         expect(user).to be_valid
       end
       
-      it 'ユーザー本名の名前のふりがなが全角カタカナである場合は登録できること' do
+      it 'ユーザー本名の名前のふりがなが全角（カタカナ）である場合は登録できること' do
         user = build(:user, first_name_kana: "ジロウ")
-        expect(user).to be_valid
-      end
-
-      it 'パスワードが7文字以上であれば登録できること' do
-        user = build(:user, password: "0000000", password_confirmation: "0000000")
         expect(user).to be_valid
       end
 
@@ -75,7 +75,7 @@ RSpec.describe User do
         expect(user.errors[:password]).to include("を入力してください")
       end
       
-      it 'パスワードが6文字以下であれば登録できないこと' do
+      it 'パスワードが6文字以下（5文字）であれば登録できないこと' do
         user = build(:user, password: "000000", password_confirmation: "000000")
         user.valid?
         expect(user.errors[:password]).to include("は7文字以上で入力してください")
@@ -88,7 +88,7 @@ RSpec.describe User do
       end
       
       it 'パスワードと確認用のパスワードが一致しない場合は登録できないこと' do
-        user = build(:user, password_confirmation: "1234567")
+        user = build(:user, password_confirmation: "12345678")
         user.valid?
         expect(user.errors[:password_confirmation]).to include("とPasswordの入力が一致しません")
       end
@@ -98,6 +98,12 @@ RSpec.describe User do
         user.valid?
         expect(user.errors[:last_name]).to include("を入力してください")
       end
+
+      it 'ユーザー本名の名字が半角カタカナの場合は登録できないこと' do
+        user = build(:user, last_name: "ﾔﾏﾀﾞ")
+        user.valid?
+        expect(user.errors[:last_name]).to include("は全角で入力して下さい")
+      end
       
       it 'ユーザー本名の名前が入力されていない場合は登録できないこと' do
         user = build(:user, first_name: "")
@@ -105,10 +111,34 @@ RSpec.describe User do
         expect(user.errors[:first_name]).to include("を入力してください")
       end
       
+      it 'ユーザー本名の名前が半角カタカナの場合は登録できないこと' do
+        user = build(:user, first_name: "ｼﾞﾛｳ")
+        user.valid?
+        expect(user.errors[:first_name]).to include("は全角で入力して下さい")
+      end
+      
       it 'ユーザー本名の名字のふりがなが入力されていない場合は登録できないこと' do
         user = build(:user, last_name_kana: "")
         user.valid?
         expect(user.errors[:last_name_kana]).to include("を入力してください")
+      end
+  
+      it 'ユーザー本名の名字のふりがなが全角（漢字）の場合は登録できないこと' do
+        user = build(:user, last_name_kana: "山田")
+        user.valid?
+        expect(user.errors[:last_name_kana]).to include("は全角カタカナで入力して下さい")
+      end
+  
+      it 'ユーザー本名の名字のふりがなが全角（ひらがな）の場合は登録できないこと' do
+        user = build(:user, last_name_kana: "やまだ")
+        user.valid?
+        expect(user.errors[:last_name_kana]).to include("は全角カタカナで入力して下さい")
+      end
+  
+      it 'ユーザー本名の名字のふりがなが半角カタカナの場合は登録できないこと' do
+        user = build(:user, last_name_kana: "ﾔﾏﾀﾞ")
+        user.valid?
+        expect(user.errors[:last_name_kana]).to include("は全角カタカナで入力して下さい")
       end
       
       it 'ユーザー本名の名前のふりがなが入力されていない場合は登録できないこと' do
@@ -116,27 +146,21 @@ RSpec.describe User do
         user.valid?
         expect(user.errors[:first_name_kana]).to include("を入力してください")
       end
-
-      it 'ユーザー本名の名字が半角の場合は登録できないこと' do
-        user = build(:user, last_name: "ﾔﾏﾀﾞ")
+      
+      it 'ユーザー本名の名前のふりがなが全角（漢字）の場合は登録できないこと' do
+        user = build(:user, first_name_kana: "次郎")
         user.valid?
-        expect(user.errors[:last_name]).to include("は全角で入力して下さい")
+        expect(user.errors[:first_name_kana]).to include("は全角カタカナで入力して下さい")
       end
       
-      it 'ユーザー本名の名前が半角の場合は登録できないこと' do
-        user = build(:user, first_name: "ｼﾞﾛｳ")
-        user.valid?
-        expect(user.errors[:first_name]).to include("は全角で入力して下さい")
-      end
-  
-      it 'ユーザー本名の名字のふりがなが全角カタカナでない場合は登録できないこと' do
-        user = build(:user, last_name_kana: "さとう")
-        user.valid?
-        expect(user.errors[:last_name_kana]).to include("は全角カタカナで入力して下さい")
-      end
-      
-      it 'ユーザー本名の名前のふりがなが全角カタカナでない場合は登録できないこと' do
+      it 'ユーザー本名の名前のふりがなが全角（ひらがな）の場合は登録できないこと' do
         user = build(:user, first_name_kana: "じろう")
+        user.valid?
+        expect(user.errors[:first_name_kana]).to include("は全角カタカナで入力して下さい")
+      end
+      
+      it 'ユーザー本名の名前のふりがなが半角カタカナの場合は登録できないこと' do
+        user = build(:user, first_name_kana: "ｼﾞﾛｳ")
         user.valid?
         expect(user.errors[:first_name_kana]).to include("は全角カタカナで入力して下さい")
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.describe User do
+  describe '#create' do
+
+    context 'can save' do
+      it '必須項目が入力されていれば登録できること' do
+        user = build(:user)
+        expect(user).to be_valid
+      end
+
+      it 'パスワードが7文字以上であれば登録できること' do
+        user = build(:user, password: "0000000", password_confirmation: "0000000")
+        expect(user).to be_valid
+      end
+      
+      
+    end
+    
+    context 'can not save' do
+      it 'ニックネームが必須であること' do
+        user = build(:user, nickname: "")
+        user.valid?
+        expect(user.errors[:nickname]).to include("を入力してください")
+      end
+      
+      it 'メールアドレスが必須であること' do
+        user = build(:user, email: "")
+        user.valid?
+        expect(user.errors[:email]).to include("を入力してください")
+      end
+      
+      it 'パスワードが必須であること' do
+        user = build(:user, password: "")
+        user.valid?
+        expect(user.errors[:password]).to include("を入力してください")
+      end
+      
+      it 'パスワードが6文字以下であれば登録できないこと' do
+        user = build(:user, password: "000000", password_confirmation: "000000")
+        user.valid?
+        expect(user.errors[:password]).to include("は7文字以上で入力してください")
+      end
+      
+      it 'パスワードを2回入力する必要があること' do
+        user = build(:user, password_confirmation: "")
+        user.valid?
+        expect(user.errors[:password_confirmation]).to include("とPasswordの入力が一致しません")
+      end
+      
+      it 'ユーザー本名の名字が必須であること' do
+        user = build(:user, last_name: "")
+        user.valid?
+        expect(user.errors[:last_name]).to include("を入力してください")
+      end
+      
+      it 'ユーザー本名の名前が必須であること' do
+        user = build(:user, first_name: "")
+        user.valid?
+        expect(user.errors[:first_name]).to include("を入力してください")
+      end
+      
+      it 'ユーザー本名の名字のふりがなが必須であること' do
+        user = build(:user, last_name_kana: "")
+        user.valid?
+        expect(user.errors[:last_name_kana]).to include("を入力してください")
+      end
+      
+      it 'ユーザー本名の名前のふりがなが必須であること' do
+        user = build(:user, first_name_kana: "")
+        user.valid?
+        expect(user.errors[:first_name_kana]).to include("を入力してください")
+      end
+      
+      it '生年月日の年が必須であること' do
+        user = build(:user, birth_year: "")
+        user.valid?
+        expect(user.errors[:birth_year]).to include("を入力してください")
+      end
+      
+      it '生年月日の月が必須であること' do
+        user = build(:user, birth_month: "")
+        user.valid?
+        expect(user.errors[:birth_month]).to include("を入力してください")
+      end
+      
+      it '生年月日の日が必須であること' do
+        user = build(:user, birth_day: "")
+        user.valid?
+        expect(user.errors[:birth_day]).to include("を入力してください")
+      end
+
+    end
+
+  end
+end


### PR DESCRIPTION
# What
UserモデルとAddressモデルにバリデーションを追加し、それぞれテストコードを追加した。
ユーザー新規登録、ログイン時に項目ごとに日本語でエラーメッセージが表示されるように設定した。
新規登録画面のパスワードのチェックボックスを選択した際にパスワードが表示されるように設定した。
お届け先情報登録時の都道府県のフォームにactive_hashを適用し、選択できるようにした。
ログイン／ログアウト時でヘッダーの表記が変わるように設定した。
ヘッダーからマイページへ、マイページからログアウトページに遷移し、ログアウトができるようにした。
DBの修正に伴いREADME、ER図の修正を行った。

# Why
バリデーション、テスト、エラーメッセージ を追加することでユーザー新規登録時の入力項目の妥当性を判断することができるため。
ログイン／ログアウト時でヘッダーの表記を変えることで、現在のログイン状態を一目で確認することができるため。