### PR TITLE
【サーバサイド】商品画像編集

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -1,11 +1,11 @@
-$(function(){
+$(document).on('turbolinks:load', ()=> {
   // カテゴリーセレクトボックスのオプションを作成
   function appendOption(category){
     let html = `<option value="${category.id}">${category.name}</option>`;
     return html;
   }
   // 子カテゴリーの表示作成
-  function appendChidrenBox(insertHTML){
+  function appendChildrenBox(insertHTML){
     let childSelectHtml = '';
     childSelectHtml = `<div class='select--wrap' id= 'children_wrapper'>
                         <select id="child__category" name="item[category_id]" class="select--wrap__box1">
@@ -45,7 +45,7 @@ $(function(){
         children.forEach(function(child){
           insertHTML += appendOption(child);
         });
-        appendChidrenBox(insertHTML);
+        appendChildrenBox(insertHTML);
       })
       .fail(function(){
         alert('カテゴリー取得に失敗しました');

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -11,7 +11,7 @@ $(document).on('turbolinks:load', ()=> {
   // プレビュー生成のための関数
   const buildImage = (index, url) => {
     const html = `<div class="preview">
-                    <img data-index="${index}" src="${url}" width="120px" height="120px">
+                    <img data-index="${index}" src="${url}">
                     <div class="img-dele-btn" id="delete_btn_${index}">削除</div>
                   </div>`;
     return html;

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -51,10 +51,9 @@ $(document).on('turbolinks:load', ()=> {
     }
   });
 
-
   // 画像用input要素に入力があったときの処理
   $('#image-box').on('change', '.js-file_group', function(e) {
-    const targetIndex = $(this).parent().data('index');
+    const targetIndex = $(this).data('index');
     // 画像URLの取得
     const file = e.target.files[0];
     const blobUrl = window.URL.createObjectURL(file);

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -55,7 +55,7 @@ $(document).on('turbolinks:load', ()=> {
     }
     
     // 画像用input要素に入れるindex番号の削除と追加
-    $('#image-box').append(buildFileField(fileIndex[0]));
+    $('#image-box').append(buildFileField(fileIndex[1]));
     fileIndex.shift();
     fileIndex.push(fileIndex[fileIndex.length - 1] + 1);
   });

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -25,7 +25,13 @@ $(document).on('turbolinks:load', ()=> {
   let lastIndex = $('.js-file_group:last').data('index');
   fileIndex.splice(0, lastIndex);
   count = fileIndex[0];
-  $('label').prop('for', `item_images_attributes_${count}_src`);
+
+  // 画像が5枚揃っている場合
+  $('.dropbox__img').prop('for', `item_images_attributes_${count}_src`);
+  if ($('.preview').length === 5) {
+    $('.dropbox__img').hide();
+  }
+  
 
   // データベースに保存されていた画像の削除ボタンが押されたときの処理
   $(document).on('click', '.data-dele-btn', function() {
@@ -33,12 +39,18 @@ $(document).on('turbolinks:load', ()=> {
     $(this).parent().remove();
     // 削除ボタンの番号の取得
     let targetIndex = $(this).attr('id').slice(11);
-    // 削除ボタンを押された画像と同じ番号を持つチェックボックスの取得
+    // 削除ボタンを押された画像と同じ番号を持つチェックボックスの取得とチェック
     const hiddenCheck = $(`input[data-index="${targetIndex}"].hidden-destroy`);
-    if (hiddenCheck) {
-      hiddenCheck.prop('checked', true);
+    hiddenCheck.prop('checked', true);
+    if ($('.preview').length < 5) {
+      $('#image-box').append(buildFileField(fileIndex[0]));
+      // labelの再表示とindex番号の追加
+      $('.dropbox__img').show();
+      fileIndex.push(fileIndex[fileIndex.length - 1] + 1);
     }
   });
+
+
 
 
   // 画像用input要素に入力があったときの処理
@@ -50,10 +62,10 @@ $(document).on('turbolinks:load', ()=> {
 
     count ++;
     // for属性を指定したlabelの追加
-    $('.dropbox__img').attr('for', `item_images_attributes_${count}_src`).before(buildImage(targetIndex, blobUrl));
+    $('.dropbox__img').prop('for', `item_images_attributes_${count}_src`).before(buildImage(targetIndex, blobUrl));
     // 画像が5枚になったらlabelの除去
     if ($('.preview').length === 5) {
-      $('label').hide();
+      $('.dropbox__img').hide();
     }
     
     // 画像用input要素に入れるindex番号の削除と追加
@@ -75,7 +87,7 @@ $(document).on('turbolinks:load', ()=> {
     if ($('.preview').length < 5) {
       $('#image-box').append(buildFileField(fileIndex[0]));
       // labelの再表示とindex番号の追加
-      $('label').show();
+      $('.dropbox__img').show();
       fileIndex.push(fileIndex[fileIndex.length - 1] + 1);
     }  
   });

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -19,7 +19,23 @@ $(document).on('turbolinks:load', ()=> {
 
   let count = 0;
   //  画像用input要素に入れるindex番号
-  let fileIndex = [1, 2, 3, 4];
+  let fileIndex = [1, 2, 3, 4, 5, 6];
+
+  // データベースに保存されていた画像分のfileIndex番号を除外
+  let lastIndex = $('.js-file_group:last').data('index');
+  fileIndex.splice(0, lastIndex);
+  count = fileIndex[0];
+
+  // データベースに保存されていた画像の削除ボタンが押されたときの処理
+  $(document).on('click', '.data-dele-btn', function() {
+    // 削除ボタンの番号の取得
+    let targetIndex = $(this).attr('id').slice(11);
+    // 削除ボタンを押された画像と同じ番号を持つチェックボックスの取得
+    const hiddenCheck = $(`input[data-index="${targetIndex}"].hidden-destroy`);
+    if (hiddenCheck) {
+      hiddenCheck.prop('checked', true);
+    }
+  });
 
 
   // 画像用input要素に入力があったときの処理
@@ -45,7 +61,7 @@ $(document).on('turbolinks:load', ()=> {
 
   // 削除ボタンが押されたときの処理
   $(document).on('click', '.img-dele-btn', function() {
-    // 削除ボタンのidの取得
+    // 削除ボタンの番号の取得
     let id = $(this).attr('id').slice(11);
     // 削除ボタンが押された画像の、input要素部分の削除
     $(`#item_images_attributes_${id}_src`).parent().remove();

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -19,12 +19,13 @@ $(document).on('turbolinks:load', ()=> {
 
   let count = 0;
   //  画像用input要素に入れるindex番号
-  let fileIndex = [1, 2, 3, 4, 5, 6];
+  let fileIndex = [0, 1, 2, 3, 4, 5, 6];
 
   // データベースに保存されていた画像分のfileIndex番号を除外
   let lastIndex = $('.js-file_group:last').data('index');
   fileIndex.splice(0, lastIndex);
   count = fileIndex[0];
+  $('label').prop('for', `item_images_attributes_${count}_src`);
 
   // データベースに保存されていた画像の削除ボタンが押されたときの処理
   $(document).on('click', '.data-dele-btn', function() {

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -1,6 +1,6 @@
 $(document).on('turbolinks:load', ()=> {
 
-  // 画像用input要素生成のための関数
+  // 画像追加用のinput要素
   const buildFileField = (index) => {
     const html = `<div class="js-file_group" data-index="${index}">
                     <input class="js-file" type="file" name="item[images_attributes][${index}][src]" id="item_images_attributes_${index}_src">
@@ -8,7 +8,7 @@ $(document).on('turbolinks:load', ()=> {
     return html;
   }
 
-  // プレビュー生成のための関数
+  // プレビュー
   const buildImage = (index, url) => {
     const html = `<div class="preview">
                     <label for="item_images_attributes_${index}_src">
@@ -19,29 +19,29 @@ $(document).on('turbolinks:load', ()=> {
     return html;
   }
 
-  // labelのfor属性につける値のカウント
+  // labelのfor属性に付ける値のカウント
   let count = 0;
-  //  画像用input要素に入れるindex番号
+  //  input要素に付けるindex番号
   let fileIndex = [0, 1, 2, 3, 4, 5, 6];
 
-  // データベースに保存されていた画像分のfileIndex番号を除外
+  // 保存済み画像に割り当てられるfileIndex番号の除外
   const lastIndex = $('.js-file_group:last').data('index');
   fileIndex.splice(0, lastIndex);
   count = fileIndex[0];
 
-  // 画像が5枚揃っている場合
+  // 保存済み画像が5枚あった場合
   $('.dropbox__img').prop('for', `item_images_attributes_${count}_src`);
   if ($('.preview').length === 5) {
     $('.dropbox__img').hide();
   }
   
-  // データベースに保存されていた画像の削除ボタンが押されたときの処理
+  // 保存済み画像の削除処理
   $(document).on('click', '.data-dele-btn', function() {
     // プレビュー部分の削除
     $(this).parent().remove();
-    // 削除ボタンの番号の取得
+    // 削除ボタン番号の取得
     let targetIndex = $(this).attr('id').slice(11);
-    // 削除ボタンを押された画像と同じ番号を持つチェックボックスの取得とチェック
+    // 削除ボタン番号と同じ番号を持つチェックボックスの取得とチェック
     const hiddenCheck = $(`input[data-index="${targetIndex}"].hidden-destroy`);
     hiddenCheck.prop('checked', true);
     // 5枚保存されていた画像が1枚でも削除された場合
@@ -53,20 +53,22 @@ $(document).on('turbolinks:load', ()=> {
     }
   });
 
-  // データベース保存済み画像に変更があったときの処理
+  // 保存済み画像の差し替え処理
   $('#image-box').on('change', '.reselection', function(e) {
+    const targetIndex = $(this).data('index');
+    const findImage = $(`.image-${targetIndex}`);
     // 画像URLの取得
     const file = e.target.files[0];
     const blobUrl = window.URL.createObjectURL(file);
     // プレビュー画像の差し替え
-    $('#reselect-image').prop('src', blobUrl);
+    $(findImage).prop('src', blobUrl);
   });
 
-  // 画像用input要素に入力があったときの処理
+  // 保存前画像の追加処理
   $('#image-box').on('change', '.js-file_group', function(e) {
     const targetIndex = $(this).data('index');
     
-    // 一度選択済みの場合
+    // 差し替える場合
     if ($.inArray(targetIndex, fileIndex) === -1) {
       const findImage = $(`.image-${targetIndex}`);
       // 画像URLの取得
@@ -81,9 +83,9 @@ $(document).on('turbolinks:load', ()=> {
       const blobUrl = window.URL.createObjectURL(file);
   
       count ++;
-      // for属性を指定したlabelの追加
+      // for属性付きのlabelの追加
       $('.dropbox__img').prop('for', `item_images_attributes_${count}_src`).before(buildImage(targetIndex, blobUrl));
-      // 画像が5枚になったらlabelの除去
+      // 画像が5枚になった時のlabelの除去
       if ($('.preview').length === 5) {
         $('.dropbox__img').hide();
       }
@@ -95,13 +97,13 @@ $(document).on('turbolinks:load', ()=> {
 
   });
 
-  // 削除ボタンが押されたときの処理
+  // 保存前画像の削除処理
   $(document).on('click', '.img-dele-btn', function() {
-    // 削除ボタンの番号の取得
+    // 削除ボタン番号の取得
     let id = $(this).attr('id').slice(11);
-    // 削除ボタンが押された画像の、input要素部分の削除
+    // 削除ボタン番号と同じ番号を持つinput要素部分の削除
     $(`#item_images_attributes_${id}_src`).parent().remove();
-    // プレビュー部分の削除
+    // プレビューの削除
     $(this).parent().remove();
     
     // 一度5枚分プレビューした画像が消された場合

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -29,6 +29,8 @@ $(document).on('turbolinks:load', ()=> {
 
   // データベースに保存されていた画像の削除ボタンが押されたときの処理
   $(document).on('click', '.data-dele-btn', function() {
+    // プレビュー部分の削除
+    $(this).parent().remove();
     // 削除ボタンの番号の取得
     let targetIndex = $(this).attr('id').slice(11);
     // 削除ボタンを押された画像と同じ番号を持つチェックボックスの取得

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -11,18 +11,21 @@ $(document).on('turbolinks:load', ()=> {
   // プレビュー生成のための関数
   const buildImage = (index, url) => {
     const html = `<div class="preview">
-                    <img data-index="${index}" src="${url}">
+                    <label for="item_images_attributes_${index}_src">
+                      <img data-index="${index}" src="${url}" id="image-preview" class="image-${index}" width="120px" height="120px">
+                    </label>
                     <div class="img-dele-btn" id="delete_btn_${index}">削除</div>
                   </div>`;
     return html;
   }
 
+  // labelのfor属性につける値のカウント
   let count = 0;
   //  画像用input要素に入れるindex番号
   let fileIndex = [0, 1, 2, 3, 4, 5, 6];
 
   // データベースに保存されていた画像分のfileIndex番号を除外
-  let lastIndex = $('.js-file_group:last').data('index');
+  const lastIndex = $('.js-file_group:last').data('index');
   fileIndex.splice(0, lastIndex);
   count = fileIndex[0];
 
@@ -32,7 +35,6 @@ $(document).on('turbolinks:load', ()=> {
     $('.dropbox__img').hide();
   }
   
-
   // データベースに保存されていた画像の削除ボタンが押されたときの処理
   $(document).on('click', '.data-dele-btn', function() {
     // プレビュー部分の削除
@@ -51,37 +53,46 @@ $(document).on('turbolinks:load', ()=> {
     }
   });
 
-
-  // データベース保存済み画像の変更があったときの処理
+  // データベース保存済み画像に変更があったときの処理
   $('#image-box').on('change', '.reselection', function(e) {
-    const targetIndex = $(this).data('index');
     // 画像URLの取得
     const file = e.target.files[0];
     const blobUrl = window.URL.createObjectURL(file);
     // プレビュー画像の差し替え
     $('#reselect-image').prop('src', blobUrl);
   });
-  
 
   // 画像用input要素に入力があったときの処理
   $('#image-box').on('change', '.js-file_group', function(e) {
     const targetIndex = $(this).data('index');
-    // 画像URLの取得
-    const file = e.target.files[0];
-    const blobUrl = window.URL.createObjectURL(file);
-
-    count ++;
-    // for属性を指定したlabelの追加
-    $('.dropbox__img').prop('for', `item_images_attributes_${count}_src`).before(buildImage(targetIndex, blobUrl));
-    // 画像が5枚になったらlabelの除去
-    if ($('.preview').length === 5) {
-      $('.dropbox__img').hide();
-    }
     
-    // 画像用input要素に入れるindex番号の削除と追加
-    $('#image-box').append(buildFileField(fileIndex[1]));
-    fileIndex.shift();
-    fileIndex.push(fileIndex[fileIndex.length - 1] + 1);
+    // 一度選択済みの場合
+    if ($.inArray(targetIndex, fileIndex) === -1) {
+      const findImage = $(`.image-${targetIndex}`);
+      // 画像URLの取得
+      const file = e.target.files[0];
+      const blobUrl = window.URL.createObjectURL(file);
+      // プレビュー画像の差し替え
+      findImage.prop('src', blobUrl);
+    }
+    else {
+      // 画像URLの取得
+      const file = e.target.files[0];
+      const blobUrl = window.URL.createObjectURL(file);
+  
+      count ++;
+      // for属性を指定したlabelの追加
+      $('.dropbox__img').prop('for', `item_images_attributes_${count}_src`).before(buildImage(targetIndex, blobUrl));
+      // 画像が5枚になったらlabelの除去
+      if ($('.preview').length === 5) {
+        $('.dropbox__img').hide();
+      }
+      // 画像用input要素に入れるindex番号の削除と追加
+      $('#image-box').append(buildFileField(fileIndex[1]));
+      fileIndex.shift();
+      fileIndex.push(fileIndex[fileIndex.length - 1] + 1);
+    }
+
   });
 
   // 削除ボタンが押されたときの処理

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -51,6 +51,18 @@ $(document).on('turbolinks:load', ()=> {
     }
   });
 
+
+  // データベース保存済み画像の変更があったときの処理
+  $('#image-box').on('change', '.reselection', function(e) {
+    const targetIndex = $(this).data('index');
+    // 画像URLの取得
+    const file = e.target.files[0];
+    const blobUrl = window.URL.createObjectURL(file);
+    // プレビュー画像の差し替え
+    $('#reselect-image').prop('src', blobUrl);
+  });
+  
+
   // 画像用input要素に入力があったときの処理
   $('#image-box').on('change', '.js-file_group', function(e) {
     const targetIndex = $(this).data('index');

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -42,6 +42,7 @@ $(document).on('turbolinks:load', ()=> {
     // 削除ボタンを押された画像と同じ番号を持つチェックボックスの取得とチェック
     const hiddenCheck = $(`input[data-index="${targetIndex}"].hidden-destroy`);
     hiddenCheck.prop('checked', true);
+    // 5枚保存されていた画像が1枚でも削除された場合
     if ($('.preview').length < 5) {
       $('#image-box').append(buildFileField(fileIndex[0]));
       // labelの再表示とindex番号の追加
@@ -51,10 +52,8 @@ $(document).on('turbolinks:load', ()=> {
   });
 
 
-
-
   // 画像用input要素に入力があったときの処理
-  $('#image-box').on('change', '.js-file', function(e) {
+  $('#image-box').on('change', '.js-file_group', function(e) {
     const targetIndex = $(this).parent().data('index');
     // 画像URLの取得
     const file = e.target.files[0];
@@ -91,5 +90,5 @@ $(document).on('turbolinks:load', ()=> {
       fileIndex.push(fileIndex[fileIndex.length - 1] + 1);
     }  
   });
-  
+
 });

--- a/app/assets/javascripts/user_registration.js
+++ b/app/assets/javascripts/user_registration.js
@@ -1,4 +1,4 @@
-$(function() {
+$(document).on('turbolinks:load', ()=> {
   $('#passcheck').change(function(){
     if ($(this).prop('checked')) {
       $('#js-password').attr('type','text');

--- a/app/assets/stylesheets/_js_preview.scss
+++ b/app/assets/stylesheets/_js_preview.scss
@@ -46,3 +46,7 @@
 .hidden-destroy {
   display: none;
 }
+
+.reselection {
+  display: none;
+}

--- a/app/assets/stylesheets/_js_preview.scss
+++ b/app/assets/stylesheets/_js_preview.scss
@@ -16,7 +16,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  & > img {
+  & img {
     margin-bottom: 5px;
     width: 120px;
     height: 120px;

--- a/app/assets/stylesheets/_js_preview.scss
+++ b/app/assets/stylesheets/_js_preview.scss
@@ -17,6 +17,7 @@
   flex-direction: column;
   align-items: center;
   & img {
+    background-color: #000;
     margin-bottom: 5px;
     width: 120px;
     height: 120px;

--- a/app/assets/stylesheets/_js_preview.scss
+++ b/app/assets/stylesheets/_js_preview.scss
@@ -19,7 +19,7 @@
   & > img {
     margin-bottom: 5px;
   }
-  .img-dele-btn {
+  .img-dele-btn, .data-dele-btn {
     border: 1px solid #3ccace;
     border-radius: 3px;
     margin: 0 auto;
@@ -41,4 +41,8 @@
   .js-file {
     display: none;
   }
+}
+
+.hidden-destroy {
+  display: none;
 }

--- a/app/assets/stylesheets/_js_preview.scss
+++ b/app/assets/stylesheets/_js_preview.scss
@@ -18,6 +18,9 @@
   align-items: center;
   & > img {
     margin-bottom: 5px;
+    width: 120px;
+    height: 120px;
+    object-fit: cover;
   }
   .img-dele-btn, .data-dele-btn {
     border: 1px solid #3ccace;

--- a/app/assets/stylesheets/_js_preview.scss
+++ b/app/assets/stylesheets/_js_preview.scss
@@ -20,7 +20,7 @@
     margin-bottom: 5px;
     width: 120px;
     height: 120px;
-    object-fit: cover;
+    object-fit: contain;
   }
   .img-dele-btn, .data-dele-btn {
     border: 1px solid #3ccace;

--- a/app/assets/stylesheets/_notifications.scss
+++ b/app/assets/stylesheets/_notifications.scss
@@ -1,0 +1,10 @@
+.Notifications {
+  background-color: rgba(255, 0, 0, 0.6);
+  width: 100%;
+  height: 40px;
+  text-align: center;
+  & > div {
+    line-height: 40px;
+    color: #fff;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,6 +3,7 @@
 @import "reset";
 @import "user";
 @import "error_message";
+@import "notifications";
 @import "new";
 @import "js_preview";
 @import "items_index/items";

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -26,7 +26,8 @@ class ItemsController < ApplicationController
     if item.update(item_params)
       redirect_to root_path
     else
-      render :edit
+      flash[:alert] = "必須項目が空欄なので更新できませんでした"
+      redirect_to edit_item_path
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+  before_action :set_item, only: [:edit, :update, :show]
   before_action :set_category, only: [:new, :edit, :create, :update, :destroy]
 
   def index
@@ -20,12 +21,10 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
-    item = Item.find(params[:id])
-    if item.update(item_params)
+    if @item.update(item_params)
       redirect_to root_path
     else
       flash[:alert] = "必須項目が空欄なので更新できませんでした"
@@ -34,7 +33,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
     @parents = Category.limit(607)
   end
 
@@ -49,6 +47,10 @@ class ItemsController < ApplicationController
   private
   def item_params
     params.require(:item).permit(:name, :price, :explain, :size, :prefecture_id, :brand, :shipping_date_id, :item_status_id, :postage_id, :category_id, images_attributes: [:src, :_destroy, :id]).merge(seller_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 
   def set_category  

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,6 +17,12 @@ class ItemsController < ApplicationController
     end
   end
 
+  def edit
+  end
+
+  def update
+  end
+
   private
   def item_params
     params.require(:item).permit(:name, :price, :explain, :size, :prefecture_id, :brand, :shipping_date_id, :item_status_id, :postage_id, :category_id, images_attributes: [:src]).merge(seller_id: current_user.id)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,7 @@ class ItemsController < ApplicationController
   end
 
   def edit
+    @item = Item.find(params[:id])
   end
 
   def update

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,11 +22,17 @@ class ItemsController < ApplicationController
   end
 
   def update
+    item = Item.find(params[:id])
+    if item.update(item_params)
+      redirect_to root_path
+    else
+      render :edit
+    end
   end
 
   private
   def item_params
-    params.require(:item).permit(:name, :price, :explain, :size, :prefecture_id, :brand, :shipping_date_id, :item_status_id, :postage_id, :category_id, images_attributes: [:src]).merge(seller_id: current_user.id)
+    params.require(:item).permit(:name, :price, :explain, :size, :prefecture_id, :brand, :shipping_date_id, :item_status_id, :postage_id, :category_id, images_attributes: [:src, :_destroy, :id]).merge(seller_id: current_user.id)
   end
 
   def buy

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -2,7 +2,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
-  process resize_to_fit: [120, 120]
+  process resize_to_fill: [720, 720, "center"]
 
   # Choose what kind of storage to use for this uploader:
   # storage :file

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -36,9 +36,9 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  # def extension_whitelist
-  #   %w(jpg jpeg gif png)
-  # end
+  def extension_whitelist
+    %w(jpg jpeg png)
+  end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -2,7 +2,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
-  process resize_to_fill: [720, 720, "center"]
+  process resize_to_limit: [720, 720]
 
   # Choose what kind of storage to use for this uploader:
   # storage :file

--- a/app/views/items/_header.html.haml
+++ b/app/views/items/_header.html.haml
@@ -17,4 +17,4 @@
         = link_to "マイページ", "/users/:id"
       - else
         = link_to "ログイン", new_user_session_path, class: "post"
-        = link_to "新規登録", new_user_registration_path, class: "post", data: {"turbolinks": false}
+        = link_to "新規登録", new_user_registration_path, class: "post"

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,0 +1,141 @@
+.exhibit__page
+  = form_with model: @item, local: true do |f|
+    .exhibit__page__main
+      .exhibit__page__main__contents
+        %h3.exhibit__page__main__contents__message
+          商品の情報を入力
+        .form-content
+          .img-form
+            %h3.img__upload__text
+              出品画像
+              %span.form--caution 
+                必須
+            %p.img__upload__comment 最大5枚までアップロードできます
+            .dropbox
+              
+            #image-box
+              #previews
+                %label{for: "item_images_attributes_0_src", class: "dropbox__img"}
+                  = icon('fas', 'camera')
+                  -# %p ドラッグアンドドロップ<br>または
+                  %p クリックしてファイルをアップロード
+
+                = f.fields_for :images, @item.images.build do |image|
+                  %div.js-file_group{data: {index: image.index}}
+                    = image.file_field :src, class: "js-file"
+                
+              = render partial: 'error_message', locals: { column: :images }
+
+        .sell--content
+          .sell--content__name
+            %h3.sell--content__name__name
+              商品名
+              %span.form--caution 
+                必須
+            %div
+              = f.text_field :name,  class: "Form__textContent", placeholder:"商品名（必須40文字まで）" 
+              = render partial: 'error_message', locals: { column: :name }
+          .sell--content__description
+            %h3.sell--content__description__description
+              商品の説明
+              %span.form--caution 
+                必須
+              = f.text_area :explain, class: "Form__textareaContent", placeholder: "商品の説明（必須1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。"
+              = render partial: 'error_message', locals: { column: :explain }
+        .product-details
+          %h3.product-details__name 商品の詳細
+          .product-details__form
+            .product-details__form__category
+              %h3.product-details__form__category__name
+                カテゴリー
+                %span.form--caution 必須
+                .select--wrap
+                  = f.collection_select :category_id, Category.where(ancestry: nil), :id, :name, {prompt: "選択してください"}, {class: "select--wrap__box"}
+                  = render partial: 'error_message', locals: { column: :category }
+  
+            .product-details__form__brand
+              %h3.product-details__form__brand__name
+                ブランド
+                %span.form--caution 任意
+                .select--wrap
+                  = f.text_field :brand, class: "select--wrap__box", placeholder:"例）シャネル" 
+                  = render partial: 'error_message', locals: { column: :brand }
+            .product-details__form__status
+              %h3.product-details__form__status__name
+                商品の状態
+                %span.form--caution 必須
+                .select--wrap
+                  = f.collection_select :item_status_id, ItemStatus.all, :id, :choice, {prompt: "選択してください"}, {class: "select--wrap__box"}
+                  = render partial: 'error_message', locals: { column: :item_status_id }
+  
+        .delivery-form
+          %h3.delivery-form__about__delivery 配送について
+          = link_to '?', new_item_path, class: 'form--question'
+          .delivery-form__box
+            .delivery-form__box__top
+              %h3.delivery-form__box__top__name
+                配送料の負担
+                %span.form--caution 必須
+              .select--wrap
+                = f.collection_select :postage_id, Postage.all, :id, :choice, {prompt: "選択してください"}, {class: "select--wrap__box"}
+                = render partial: 'error_message', locals: { column: :postage_id }
+
+            .delivery-form__box__middle
+              %h3.delivery-form__box__top__name
+                発送元の地域
+                %span.form--caution 必須
+              .select--wrap
+                = f.collection_select :prefecture_id, Prefecture.all, :id, :name, {prompt: "選択してください"}, {class: "select--wrap__box"}
+                = render partial: 'error_message', locals: { column: :prefecture_id }
+
+            .delivery-form__box__bottom
+              %h3.delivery-form__box__top__name
+                発送までの日数
+                %span.form--caution 必須
+              .select--wrap
+                = f.collection_select :shipping_date_id, ShippingDate.all, :id, :choice, {prompt: "選択してください"}, {class: "select--wrap__box"}
+                = render partial: 'error_message', locals: { column: :shipping_date_id }
+
+        .product-price
+          %h3.product-price__name 価格(300〜9,999,999)
+          = link_to '?', new_item_path, class: 'form--question'
+          .product-price__form
+            .product-price__form__left
+              %h3.product-price__form__name
+                販売価格
+              %span.form--caution 必須
+            .select--wrap
+              ¥
+              = f.number_field :price, in: 300..9999999, step:1, class: "select--wrap__box"
+              = render partial: 'error_message', locals: { column: :price }
+            
+        .submit-button
+          .actions
+            = f.submit "出品する", class: "btn--lightblue"
+          = link_to 'もどる', new_item_path, class: 'btn--bule'
+          .subimit-button__text
+            = link_to '禁止されている出品', new_item_path, class: 'submit__text'
+            、
+            = link_to '行為', new_item_path, class: 'submit__text'
+            を必ずご確認ください。
+            %p.sell--content5__p
+              またブランド品でシリアルナンバー等がある場合はご記載ください。
+              = link_to '偽ブランドの販売', new_item_path, class: 'submit__text'
+              は犯罪であり処罰される可能性があります。
+            %p.sell--content5__p
+              また、出品をもちまして
+              = link_to '加盟店規約', new_item_path, class: 'submit__text'
+              に同意したことになります。
+
+.exhibit-page__footer
+  .exhibit-page__footer__content
+    .exhibit-page__footer__content__main
+      %ul.exhibit-page__footer__lists
+        %li.exhibit-page__footer__list
+          プライバシーポリシー
+        %li.exhibit-page__footer__list
+          FURIMA利用規約
+        %li.exhibit-page__footer__list
+          特定商取引に関する表記
+        %p.exhibit-page__footer__copyright
+          2020 FURIMA

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -18,7 +18,8 @@
                 - if @item.persisted?
                   - @item.images.each_with_index do |image, i|
                     .preview
-                      = image_tag image.src.url, data: {index: i}, width: "120px", height: "120px"
+                      %label{for: "item_images_attributes_#{i}_src"}
+                        = image_tag image.src.url, data: {index: i}, width: "120px", height: "120px"
                       %div{class: "data-dele-btn", id: "delete-num-#{i}"} 削除
                 %label{for: "item_images_attributes_0_src", class: "dropbox__img"}
                   = icon('fas', 'camera')
@@ -26,7 +27,7 @@
                   %p クリックしてファイルをアップロード
 
               = f.fields_for :images do |image|
-                %div.js-file_group{data: {index: image.index}}
+                %div{data: {index: image.index}}
                   = image.file_field :src, class: "js-file"
                   - if @item.persisted?
                     = image.check_box :_destroy, data: { index: image.index }, class: "hidden-destroy"

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,3 +1,7 @@
+- if flash[:alert]
+  .Notifications
+    - flash.each do |key, value|
+      = content_tag(:div, value, class: key)
 .exhibit__page
   = form_with model: @item, local: true do |f|
     .exhibit__page__main

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -19,7 +19,7 @@
                   - @item.images.each_with_index do |image, i|
                     .preview
                       %label{for: "item_images_attributes_#{i}_src"}
-                        = image_tag image.src.url, data: {index: i}, width: "120px", height: "120px"
+                        = image_tag image.src.url, data: {index: i}, width: "120px", height: "120px", id: "reselect-image"
                       %div{class: "data-dele-btn", id: "delete-num-#{i}"} 削除
                 %label{for: "item_images_attributes_0_src", class: "dropbox__img"}
                   = icon('fas', 'camera')
@@ -27,7 +27,7 @@
                   %p クリックしてファイルをアップロード
 
               = f.fields_for :images do |image|
-                %div{data: {index: image.index}}
+                %div{ data: {index: image.index}, class: "reselection" }
                   = image.file_field :src, class: "js-file"
                   - if @item.persisted?
                     = image.check_box :_destroy, data: { index: image.index }, class: "hidden-destroy"

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -39,8 +39,6 @@
                 %div{ data: {index: @item.images.count}, class: "js-file_group" }
                   = file_field_tag "item_images_attributes_#{@item.images.count}_src", name: "item[images_attributes][#{@item.images.count}][src]", class: "js-file"
                 
-                  
-                
               = render partial: 'error_message', locals: { column: :images }
 
         .sell--content

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -123,7 +123,7 @@
             
         .submit-button
           .actions
-            = f.submit "出品する", class: "btn--lightblue"
+            = f.submit "更新する", class: "btn--lightblue"
           = link_to 'もどる', new_item_path, class: 'btn--bule'
           .subimit-button__text
             = link_to '禁止されている出品', new_item_path, class: 'submit__text'

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -23,7 +23,7 @@
                   - @item.images.each_with_index do |image, i|
                     .preview
                       %label{for: "item_images_attributes_#{i}_src"}
-                        = image_tag image.src.url, data: {index: i}, width: "120px", height: "120px", id: "reselect-image"
+                        = image_tag image.src.url, data: {index: i}, width: "120px", height: "120px", id: "reselect-image", class: "image-#{i}"
                       %div{class: "data-dele-btn", id: "delete-num-#{i}"} 削除
                 %label{for: "item_images_attributes_0_src", class: "dropbox__img"}
                   = icon('fas', 'camera')

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -65,7 +65,7 @@
                 カテゴリー
                 %span.form--caution 必須
                 .select--wrap
-                  = f.collection_select :category_id, Category.where(ancestry: nil), :id, :name, {prompt: "選択してください"}, {class: "select--wrap__box"}
+                  = f.collection_select :category_id, @category_parent_array, :id, :name,{ include_blank: "選択してください"},class:"select--wrap__box1"
                   = render partial: 'error_message', locals: { column: :category }
   
             .product-details__form__brand

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -32,7 +32,7 @@
                     = image.check_box :_destroy, data: { index: image.index }, class: "hidden-destroy"
               - if @item.persisted?
                 %div{ data: {index: @item.images.count}, class: "js-file_group" }
-                  = file_field_tag :src, name: "item[images_attributes][#{@item.images.count}][src]", class: "js-file"
+                  = file_field_tag "item_images_attributes_#{@item.images.count}_src", name: "item[images_attributes][#{@item.images.count}][src]", class: "js-file"
                 
                   
                 

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -15,14 +15,26 @@
               
             #image-box
               #previews
+                - if @item.persisted?
+                  - @item.images.each_with_index do |image, i|
+                    .preview
+                      = image_tag image.src.url, data: {index: i}, width: "120px", height: "120px"
+                      %div{class: "img-dele-btn"} 削除
                 %label{for: "item_images_attributes_0_src", class: "dropbox__img"}
                   = icon('fas', 'camera')
                   -# %p ドラッグアンドドロップ<br>または
                   %p クリックしてファイルをアップロード
 
-                = f.fields_for :images, @item.images.build do |image|
-                  %div.js-file_group{data: {index: image.index}}
-                    = image.file_field :src, class: "js-file"
+              = f.fields_for :images do |image|
+                %div.js-file_group{data: {index: image.index}}
+                  = image.file_field :src, class: "js-file"
+                  - if @item.persisted?
+                    = image.check_box :_destroy, data: { index: image.index }, class: "hidden-destroy"
+              - if @item.persisted?
+                %div{ data: {index: @item.images.count}, class: "js-file_group" }
+                  = file_field_tag :src, name: "item[images_attributes][#{@item.images.count}][src]", class: "js-file"
+                
+                  
                 
               = render partial: 'error_message', locals: { column: :images }
 

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -19,7 +19,7 @@
                   - @item.images.each_with_index do |image, i|
                     .preview
                       = image_tag image.src.url, data: {index: i}, width: "120px", height: "120px"
-                      %div{class: "img-dele-btn"} 削除
+                      %div{class: "data-dele-btn", id: "delete-num-#{i}"} 削除
                 %label{for: "item_images_attributes_0_src", class: "dropbox__img"}
                   = icon('fas', 'camera')
                   -# %p ドラッグアンドドロップ<br>または

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
     post 'addresses', to: 'users/registrations#create_address'
   end
   root 'items#index'
-  resources :items, only: [:new, :create] do
+  resources :items, only: [:new, :create, :edit, :update] do
     member do
       get 'buy'
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,11 +29,6 @@ ActiveRecord::Schema.define(version: 2020_08_14_074941) do
     t.index ["user_id"], name: "index_addresses_on_user_id"
   end
 
-  create_table "cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "ancestry"


### PR DESCRIPTION
# What
出品した商品情報の編集機能を、以下の通りに実装する。

#### 編集画面
- 商品出品画面とほぼ同じUIとする
- 開いた時点で保存された商品情報が表示される

#### 保存済み画像
- 5枚未満の場合は画像の追加ができる
- 変更したい画像のクリックによって一枚ごとの差し替えを可能とする
- 削除ボタンが押された画像は、更新作業が実行された時点でデータベースから削除できる

また今回の実装に伴い、保存前の画像の差し替えも可能とした。

なお、本ブランチにおいては画像編集機能を主とし、ancestryを利用した子孫カテゴリーの表示および変更は行わない。また、別ブランチで単体テストを行うこととする。

# Why
情報の劣化を防ぎ、売買する際の検討材料の質を高めることで、ユーザビリティを向上させるため。