### PR TITLE
active_hashのデータの修正

### DIFF
--- a/app/models/postage.rb
+++ b/app/models/postage.rb
@@ -1,9 +1,8 @@
 class Postage < ActiveHash::Base
   include ActiveHash::Associations
   field :choice
-  add id: 1, choice: "1~2日で発送"
-  add id: 2, choice: "2~3日で発送"
-  add id: 3, choice: "4~7日で発送"
+  add id: 1, choice: "送料込み(出品者負担)"
+  add id: 2, choice: "着払い(購入者負担)"
 
   has_many :items
 end

--- a/app/models/shipping_date.rb
+++ b/app/models/shipping_date.rb
@@ -1,8 +1,9 @@
 class ShippingDate < ActiveHash::Base
   include ActiveHash::Associations
   field :choice
-  add id: 1, choice: "送料込み(出品者負担)"
-  add id: 2, choice: "着払い(購入者負担)"
+  add id: 1, choice: "1~2日で発送"
+  add id: 2, choice: "2~3日で発送"
+  add id: 3, choice: "4~7日で発送"
 
   has_many :items
 end


### PR DESCRIPTION
# What
active_hashで管理している配送料の負担（postage）と発送までの日数（shipping_date）の選択肢のデータが逆になっていたため、差し替えを行った。

# Why
説明文と選択肢の齟齬による混乱を防ぐため。