### PR TITLE
画像ファイルのサイズ上限

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -4,6 +4,10 @@ class ImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
   process resize_to_limit: [720, 720]
 
+  def size_range
+    1.byte..1.megabytes
+  end
+
   # Choose what kind of storage to use for this uploader:
   # storage :file
   storage :fog


### PR DESCRIPTION
# What
画像ファイルが1MBより大きい場合に保存処理ができないよう記述を追加した。

# Why
現行のサーバー設定だと1MBより大きいファイルの保存はできず、エラーになるため。