### PR TITLE
販売手数料と販売利益

### DIFF
--- a/app/assets/javascripts/price.js
+++ b/app/assets/javascripts/price.js
@@ -1,0 +1,3 @@
+$(document).on('turbolinks:load', ()=> {
+
+});

--- a/app/assets/javascripts/price.js
+++ b/app/assets/javascripts/price.js
@@ -5,6 +5,8 @@ $(document).on('turbolinks:load', ()=> {
     const profit = this.value - fee;
     $('#fee').text(`¥ ${fee}`);
     $('#profit').text(`¥ ${profit}`);
+
+    $('#hidden-price').prop('value', profit);
   });
 
 });

--- a/app/assets/javascripts/price.js
+++ b/app/assets/javascripts/price.js
@@ -1,3 +1,10 @@
 $(document).on('turbolinks:load', ()=> {
 
+  $('.select--wrap').on('change', '#price', function() {
+    const fee = Math.floor(this.value * 0.1);
+    const profit = this.value - fee;
+    $('#fee').text(`¥ ${fee}`);
+    $('#profit').text(`¥ ${profit}`);
+  });
+
 });

--- a/app/assets/javascripts/price.js
+++ b/app/assets/javascripts/price.js
@@ -9,4 +9,13 @@ $(document).on('turbolinks:load', ()=> {
     $('#hidden-price').prop('value', profit);
   });
 
+  $('.select--wrap').on('keydown', '#price', function() {
+    const fee = Math.floor(this.value * 0.1);
+    const profit = this.value - fee;
+    $('#fee').text(`¥ ${fee}`);
+    $('#profit').text(`¥ ${profit}`);
+
+    $('#hidden-price').prop('value', profit);
+  });
+
 });

--- a/app/assets/javascripts/price.js
+++ b/app/assets/javascripts/price.js
@@ -1,15 +1,6 @@
 $(document).on('turbolinks:load', ()=> {
 
-  $('.select--wrap').on('change', '#price', function() {
-    const fee = Math.floor(this.value * 0.1);
-    const profit = this.value - fee;
-    $('#fee').text(`¥ ${fee}`);
-    $('#profit').text(`¥ ${profit}`);
-
-    $('#hidden-price').prop('value', profit);
-  });
-
-  $('.select--wrap').on('keydown', '#price', function() {
+  $('.select--wrap').on('change keydown', '#price', function() {
     const fee = Math.floor(this.value * 0.1);
     const profit = this.value - fee;
     $('#fee').text(`¥ ${fee}`);

--- a/app/assets/stylesheets/_new.scss
+++ b/app/assets/stylesheets/_new.scss
@@ -234,7 +234,7 @@
       }
       // 販売価格
       .product-price {
-        height: 260px; 
+        height: 350px; 
         padding:40px;
         border-bottom: 1px solid #EEEEEE;
         &__name{
@@ -253,11 +253,12 @@
           float: left;
         }
         &__form {
-          float:right;
+          padding: 20px 10px 0 0;
+          display: flex;
           width:100%;
           &__left {
             width:100%;
-            padding: 30px 0;
+            padding-top: 20px;
             .form--caution {
               @include form-caution;
               margin-left: 20px;
@@ -265,19 +266,17 @@
             }
           }
           .select--wrap {
-            // float: right;
             width:100%;
             display: inline;
-            margin-top: 23px;
             @include select-wrap;
               &__box{
-                width: 97%;
+                width: 100%;
                 height: 48px;
                 border: 1px solid #ccc;
                 position: relative;
                 background: 0;
-                // -webkit-appearance: none;
-                padding: 0 40px;
+                padding-left: 0 40px;
+                text-align: right;
               }
           }
         }
@@ -352,5 +351,30 @@
       margin-top: 30px;
       padding-right: 20px;
     }
+  }
+}
+
+.price-field {
+  width: 100%;
+  display: flex;
+  & > span {
+    padding-right: 10px;
+    line-height: 42px;
+  }
+}
+
+.Sales-price {
+  padding-right: 20px;
+  display: flex;
+  justify-content: space-between;
+  & > p, span {
+    line-height: 60px;
+    font-size: 14px;
+  }
+  &.fee {
+    padding-top: 20px;    
+  }
+  &.profit {
+    border-top: 1px solid #eee;
   }
 }

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -105,9 +105,16 @@
                 販売価格
               %span.form--caution 必須
             .select--wrap
-              ¥
-              = f.number_field :price, in: 300..9999999, step:1, class: "select--wrap__box"
+              .price-field
+                %span ¥
+                = f.number_field :price, in: 300..9999999, step:1, class: "select--wrap__box", id: "price"
               = render partial: 'error_message', locals: { column: :price }
+          .Sales-price.fee
+            %p 販売手数料 (10%)
+            %span#fee ー
+          .Sales-price.profit
+            %p 販売利益
+            %span#profit ー
             
         .submit-button
           .actions

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -115,6 +115,7 @@
           .Sales-price.profit
             %p 販売利益
             %span#profit ー
+            = f.hidden_field :price, value: "", id: "hidden-price"
             
         .submit-button
           .actions


### PR DESCRIPTION
# What
入力された販売価格から、販売手数料の10%を算出/表示し、販売利益を計算/表示する機能を実装する。
また、現行ではitemsテーブルのpriceからむに保存される値が販売価格だったものを、販売利益に変更し保存されるようにする。

# Why
出品者にかかる販売手数料が、販売価格に含まれて表示されているものを直すため。