### PR TITLE
画像サイズの設定

### DIFF
--- a/app/assets/stylesheets/items_index/_items.scss
+++ b/app/assets/stylesheets/items_index/_items.scss
@@ -43,4 +43,11 @@ p {
   &:hover {
     background-color: lighten($furima-blue, 8%);
   }
+  & a {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
 }

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -5,7 +5,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   process resize_to_limit: [720, 720]
 
   def size_range
-    1.byte..1.megabytes
+    1.byte..100.kilobytes
   end
 
   # Choose what kind of storage to use for this uploader:

--- a/app/views/items/_sell_btn.html.haml
+++ b/app/views/items/_sell_btn.html.haml
@@ -1,3 +1,4 @@
 .Sell-btn
   %p 出品する
-  = link_to image_tag('material/icon/icon_camera.png', alt: '出品ページへのリンクボタン', width: '54', height: '54'), new_item_path
+  = image_tag('material/icon/icon_camera.png', alt: '出品ページへのリンクボタン', width: '54', height: '54')
+  = link_to '', new_item_path

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -10,7 +10,7 @@
               出品画像
               %span.form--caution 
                 必須
-            %p.img__upload__comment 最大5枚までアップロードできます
+            %p.img__upload__comment 最大5枚までアップロードできます（jpg/jpeg/png画像、上限100KBまで）
             .dropbox
               
             #image-box

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -10,7 +10,7 @@
               出品画像
               %span.form--caution 
                 必須
-            %p.img__upload__comment 最大5枚までアップロードできます
+            %p.img__upload__comment 最大5枚までアップロードできます（jpg/jpeg/png画像、上限100KBまで）
             .dropbox
               
             #image-box


### PR DESCRIPTION
# What
本番環境において、現行の設定ではbodyサイズが1MBを超えるとエラー画面になるため、画像のサイズの制限を再設定した。

# Why
画像投稿の制限を明確にし、エラー画面表示によるユーザーの混乱を防ぐため。